### PR TITLE
feat(systemd): migrate helper to socket activation with installer flow

### DIFF
--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -20,59 +20,87 @@ class DisplayManager:
     # ThinkBook Plus Gen 4 IRU hardware specifications
     OLED_RESOLUTION_WH = [2880, 1800]
     EINK_RESOLUTION_WH = [2560, 1600]
+    
+    # Display name to resolution mapping for easy extension
+    DISPLAY_RESOLUTIONS = {
+        'eDP-1': [2880, 1800],  # OLED
+        'eDP-2': [2560, 1600],  # E-Ink
+    }
+    
+    # Timing constants (seconds)
+    XRANDR_APPLY_DELAY = 0.2
+    IMAGE_DISPLAY_DELAY = 0.5
+    XRANDR_TIMEOUT = 5
+    WHICH_TIMEOUT = 2
+    
+    # Cache timeout for xrandr queries (seconds)
+    XRANDR_CACHE_TTL = 0.5
 
     def __init__(self, logger):
         self.logger = logger
+        self._xrandr_cache = None
+        self._xrandr_cache_time = 0
+    
+    def _get_xrandr_output(self):
+        """Get cached xrandr output to reduce subprocess overhead"""
+        current_time = time.time()
+        if self._xrandr_cache is not None and (current_time - self._xrandr_cache_time) < self.XRANDR_CACHE_TTL:
+            return self._xrandr_cache
+        
+        try:
+            result = subprocess.run(
+                ['xrandr', '--query'],
+                capture_output=True,
+                text=True,
+                timeout=self.XRANDR_TIMEOUT
+            )
+            
+            if result.returncode != 0:
+                self.logger.error(f"xrandr error: {result.stderr}")
+                return None
+            
+            self._xrandr_cache = result.stdout
+            self._xrandr_cache_time = current_time
+            return result.stdout
+            
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"xrandr query timed out after {self.XRANDR_TIMEOUT}s")
+            return None
+        except Exception as e:
+            self.logger.error(f"Failed to query xrandr: {e}")
+            return None
     
     def get_displays(self):
         """Get list of connected displays using xrandr"""
-        try:
-            result = subprocess.run(
-                ['xrandr', '--query'],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-            
-            displays = []
-            for line in result.stdout.split('\n'):
-                if ' connected' in line:
-                    parts = line.split()
-                    name = parts[0]
-                    primary = 'primary' in line
-                    displays.append({'name': name, 'primary': primary})
-            
-            return displays
-            
-        except Exception as e:
-            self.logger.error(f"Failed to get displays: {e}")
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
             return []
+        
+        displays = []
+        for line in xrandr_output.split('\n'):
+            if ' connected' in line:
+                parts = line.split()
+                name = parts[0]
+                primary = 'primary' in line
+                displays.append({'name': name, 'primary': primary})
+        
+        return displays
     
     def is_display_active(self, display_name):
         """Check if a display is currently active (enabled and has geometry)"""
-        try:
-            result = subprocess.run(
-                ['xrandr', '--query'],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-
-            for line in result.stdout.split('\n'):
-                if display_name in line and ' connected' in line:
-                    parts = line.split()
-                    # Display is active if it has geometry info (e.g., 1920x1080+0+0)
-                    # Look for pattern like "1920x1080+0+0" in the line
-                    for part in parts:
-                        if 'x' in part and '+' in part:
-                            return True
-                    return False
-
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
             return False
-
-        except Exception as e:
-            self.logger.error(f"Failed to check display status: {e}")
-            return False
+        
+        for line in xrandr_output.split('\n'):
+            if display_name in line and ' connected' in line:
+                # Display is active if it has geometry info (e.g., 1920x1080+0+0)
+                for part in line.split():
+                    if 'x' in part and '+' in part:
+                        return True
+                return False
+        
+        return False
 
     def enable_display(self, display_name, scale=None):
         """Enable/turn on a display with optional scaling
@@ -84,12 +112,9 @@ class DisplayManager:
                    This keeps touch input properly mapped.
         """
         try:
-            # Determine native resolution based on display name
-            # eDP-1 is OLED, eDP-2 is E-Ink on ThinkBook Plus Gen 4
-            if display_name == "eDP-1":
-                native_width, native_height = self.OLED_RESOLUTION_WH
-            elif display_name == "eDP-2":
-                native_width, native_height = self.EINK_RESOLUTION_WH
+            # Determine native resolution from display name mapping
+            if display_name in self.DISPLAY_RESOLUTIONS:
+                native_width, native_height = self.DISPLAY_RESOLUTIONS[display_name]
             else:
                 self.logger.warning(f"Unknown display {display_name}, using auto mode")
                 native_width, native_height = None, None
@@ -129,15 +154,24 @@ class DisplayManager:
                 cmd.append('--auto')
 
             # Run xrandr command (may produce spurious BadMatch errors on stderr)
-            subprocess.run(
-                cmd,
-                capture_output=True,
-                timeout=5
-            )
-
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    timeout=self.XRANDR_TIMEOUT
+                )
+                if result.returncode != 0:
+                    self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
+            except subprocess.TimeoutExpired:
+                self.logger.error(f"xrandr enable command timed out after {self.XRANDR_TIMEOUT}s")
+                return False
+            
+            # Invalidate cache since display state changed
+            self._xrandr_cache = None
+            
             # Verify the display is actually enabled by checking its state
             # Give X11 a moment to apply the change
-            time.sleep(0.2)
+            time.sleep(self.XRANDR_APPLY_DELAY)
 
             if self.is_display_active(display_name):
                 scale_info = f" with {scale}x scale" if scale and scale != 1.0 else ""
@@ -155,15 +189,24 @@ class DisplayManager:
         """Disable/turn off a display"""
         try:
             # Run xrandr command (may produce spurious BadMatch errors on stderr)
-            subprocess.run(
-                ['xrandr', '--output', display_name, '--off'],
-                capture_output=True,
-                timeout=5
-            )
-
+            try:
+                result = subprocess.run(
+                    ['xrandr', '--output', display_name, '--off'],
+                    capture_output=True,
+                    timeout=self.XRANDR_TIMEOUT
+                )
+                if result.returncode != 0:
+                    self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
+            except subprocess.TimeoutExpired:
+                self.logger.error(f"xrandr disable command timed out after {self.XRANDR_TIMEOUT}s")
+                return False
+            
+            # Invalidate cache since display state changed
+            self._xrandr_cache = None
+            
             # Verify the display is actually disabled by checking its state
             # Give X11 a moment to apply the change
-            time.sleep(0.2)
+            time.sleep(self.XRANDR_APPLY_DELAY)
 
             if not self.is_display_active(display_name):
                 self.logger.info(f"Disabled display: {display_name}")
@@ -179,16 +222,13 @@ class DisplayManager:
     def get_display_geometry(self, display_name):
         """Get the geometry (position and size) of a display using xrandr"""
         try:
-            result = subprocess.run(
-                ['xrandr', '--query'],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
+            xrandr_output = self._get_xrandr_output()
+            if not xrandr_output:
+                return None
 
             # Parse xrandr output to find the display geometry
             # Format: "eDP-2 connected 1200x1920+1920+0 ..."
-            for line in result.stdout.split('\n'):
+            for line in xrandr_output.split('\n'):
                 if display_name in line and 'connected' in line:
                     # Look for the geometry pattern: WIDTHxHEIGHT+X+Y
                     parts = line.split()
@@ -258,7 +298,7 @@ class DisplayManager:
                 process = subprocess.Popen(cmd)
 
                 # Give it a moment to display
-                time.sleep(0.5)
+                time.sleep(self.IMAGE_DISPLAY_DELAY)
 
                 return process
 
@@ -278,7 +318,7 @@ class DisplayManager:
                 self.logger.warning("imv may not position on correct display automatically")
                 process = subprocess.Popen(cmd)
 
-                time.sleep(0.5)
+                time.sleep(self.IMAGE_DISPLAY_DELAY)
                 return process
 
             except Exception as e:
@@ -299,8 +339,11 @@ class DisplayManager:
                 ['which', command],
                 capture_output=True,
                 check=True,
-                timeout=2
+                timeout=self.WHICH_TIMEOUT
             )
             return True
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        except subprocess.CalledProcessError:
+            return False
+        except subprocess.TimeoutExpired:
+            self.logger.warning(f"Command check for '{command}' timed out")
             return False

--- a/HelperClient.py
+++ b/HelperClient.py
@@ -12,46 +12,81 @@ import socket
 import struct
 import json
 import threading
+import time
 
 
 class HelperClient:
     """Client for communicating with privileged helper daemon via Unix socket"""
+    
+    # Connection retry settings
+    MAX_RETRIES = 3
+    RETRY_DELAYS = [0.5, 1.0, 2.0]  # Exponential backoff
     
     def __init__(self, logger):
         self.logger = logger
         self.socket = None
         self.connected = False
         self.lock = threading.Lock()
+        self.socket_path = None
+        self.last_error = None
     
     def connect(self, socket_path, timeout=10.0):
-        """Connect to helper daemon socket"""
-        try:
-            self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.socket.settimeout(timeout)
-            self.socket.connect(socket_path)
-            self.connected = True
-            self.logger.info(f"Connected to helper daemon at {socket_path}")
-            return True
-        except Exception as e:
-            self.logger.error(f"Failed to connect to helper: {e}")
-            self.connected = False
-            return False
+        """Connect to helper daemon socket with retry logic"""
+        self.socket_path = socket_path
+        
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                # Clean up any existing socket
+                self._close_socket()
+                
+                self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                self.socket.settimeout(timeout)
+                self.socket.connect(socket_path)
+                
+                # Verify connection with a quick test
+                self.socket.setblocking(False)
+                self.socket.setblocking(True)
+                
+                self.connected = True
+                self.last_error = None
+                self.logger.info(f"Connected to helper daemon at {socket_path}")
+                return True
+                
+            except socket.error as e:
+                self.last_error = str(e)
+                self.logger.warning(f"Connection attempt {attempt + 1}/{self.MAX_RETRIES} failed: {e}")
+                self._close_socket()
+                
+                # Wait before retry (except on last attempt)
+                if attempt < self.MAX_RETRIES - 1:
+                    time.sleep(self.RETRY_DELAYS[attempt])
+            
+            except Exception as e:
+                self.last_error = str(e)
+                self.logger.error(f"Unexpected error connecting to helper: {e}")
+                self._close_socket()
+                break
+        
+        self.connected = False
+        return False
     
     def disconnect(self):
         """Disconnect from helper daemon"""
-        if self.socket:
-            try:
-                # Send shutdown command
-                self.send_command('shutdown')
-            except:
-                pass
-            
-            try:
-                self.socket.close()
-            except:
-                pass
+        with self.lock:
+            if self.socket:
+                try:
+                    # Send shutdown command with timeout
+                    old_timeout = self.socket.gettimeout()
+                    self.socket.settimeout(2.0)  # Short timeout for shutdown
+                    self.send_command('shutdown')
+                    self.socket.settimeout(old_timeout)
+                except Exception as e:
+                    self.logger.debug(f"Error sending shutdown command: {e}")
+                
+                self._close_socket()
             
             self.connected = False
+            self.socket_path = None
             self.logger.info("Disconnected from helper daemon")
     
     def send_command(self, command, **params):
@@ -60,7 +95,7 @@ class HelperClient:
         Returns: response dict or None on error
         """
         if not self.connected or not self.socket:
-            raise RuntimeError("Not connected to helper daemon")
+            raise RuntimeError(f"Not connected to helper daemon. Last error: {self.last_error}")
         
         with self.lock:
             try:
@@ -73,42 +108,110 @@ class HelperClient:
                 # Serialize to JSON
                 message = json.dumps(command_data).encode('utf-8')
                 
+                # Validate message size (prevent overflow)
+                if len(message) > 1024 * 1024:  # 1MB limit
+                    raise ValueError(f"Message too large: {len(message)} bytes")
+                
                 # Send with length prefix
                 length_prefix = struct.pack('!I', len(message))
-                self.socket.sendall(length_prefix + message)
+                self._sendall_with_check(length_prefix + message)
                 
-                # Receive response length
+                # Receive response length with timeout handling
                 length_data = self._recv_exact(4)
                 if not length_data:
-                    raise RuntimeError("Connection closed by helper")
+                    raise RuntimeError("Connection closed by helper (no length header)")
                 
                 response_length = struct.unpack('!I', length_data)[0]
+                
+                # Validate response length
+                if response_length > 1024 * 1024:  # 1MB limit
+                    raise ValueError(f"Response too large: {response_length} bytes")
                 
                 # Receive response data
                 response_data = self._recv_exact(response_length)
                 if not response_data:
-                    raise RuntimeError("Connection closed by helper")
+                    raise RuntimeError("Connection closed by helper (incomplete response)")
                 
                 # Parse JSON response
-                response = json.loads(response_data.decode('utf-8'))
+                try:
+                    response = json.loads(response_data.decode('utf-8'))
+                except json.JSONDecodeError as e:
+                    raise RuntimeError(f"Invalid JSON response from helper: {e}")
                 
                 return response
                 
-            except Exception as e:
-                self.logger.error(f"Command error: {e}")
+            except socket.timeout as e:
+                self.logger.error(f"Command '{command}' timed out: {e}")
                 self.connected = False
+                self.last_error = f"Timeout: {e}"
+                raise RuntimeError(f"Command timed out: {e}")
+            
+            except socket.error as e:
+                self.logger.error(f"Socket error during '{command}': {e}")
+                self.connected = False
+                self.last_error = f"Socket error: {e}"
+                raise RuntimeError(f"Socket error: {e}")
+            
+            except Exception as e:
+                self.logger.error(f"Command '{command}' error: {e}")
+                self.connected = False
+                self.last_error = str(e)
                 raise
     
     def _recv_exact(self, num_bytes):
-        """Receive exactly num_bytes from socket"""
+        """Receive exactly num_bytes from socket with timeout handling"""
         data = b''
         while len(data) < num_bytes:
-            chunk = self.socket.recv(num_bytes - len(data))
-            if not chunk:
+            try:
+                chunk = self.socket.recv(num_bytes - len(data))
+                if not chunk:
+                    self.logger.warning(f"Connection closed while receiving data (got {len(data)}/{num_bytes} bytes)")
+                    return None
+                data += chunk
+            except socket.timeout:
+                self.logger.error(f"Timeout while receiving data (got {len(data)}/{num_bytes} bytes)")
+                raise
+            except socket.error as e:
+                self.logger.error(f"Socket error while receiving: {e}")
                 return None
-            data += chunk
         return data
+    
+    def _sendall_with_check(self, data):
+        """Send all data with error checking"""
+        try:
+            self.socket.sendall(data)
+        except socket.timeout:
+            self.logger.error("Timeout while sending data")
+            raise
+        except socket.error as e:
+            self.logger.error(f"Socket error while sending: {e}")
+            raise
+    
+    def _close_socket(self):
+        """Close socket safely"""
+        if self.socket:
+            try:
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except:
+                pass
+            try:
+                self.socket.close()
+            except:
+                pass
+            self.socket = None
     
     def is_connected(self):
         """Check if connected to helper"""
-        return self.connected
+        if not self.connected:
+            return False
+        
+        # Verify socket is still alive
+        if not self.socket:
+            self.connected = False
+            return False
+        
+        return True
+    
+    def get_last_error(self):
+        """Get the last connection error"""
+        return self.last_error

--- a/HelperClient.py
+++ b/HelperClient.py
@@ -71,20 +71,11 @@ class HelperClient:
         return False
     
     def disconnect(self):
-        """Disconnect from helper daemon"""
+        """Disconnect from helper daemon client socket only (no server shutdown)."""
         with self.lock:
             if self.socket:
-                try:
-                    # Send shutdown command with timeout
-                    old_timeout = self.socket.gettimeout()
-                    self.socket.settimeout(2.0)  # Short timeout for shutdown
-                    self.send_command('shutdown')
-                    self.socket.settimeout(old_timeout)
-                except Exception as e:
-                    self.logger.debug(f"Error sending shutdown command: {e}")
-                
                 self._close_socket()
-            
+
             self.connected = False
             self.socket_path = None
             self.logger.info("Disconnected from helper daemon")

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -26,16 +26,18 @@ import struct
 import signal
 import threading
 import logging
+import atexit
 
 from WatchdogTimer import WatchdogTimer
 from ECController import ECController
 from EInkUSBController import EInkUSBController 
 
 # Configuration
-SOCKET_PATH = '/tmp/tinta4plus.sock'
+SOCKET_PATH = '/run/tinta4plus.sock'
 PID_FILE = '/tmp/tinta4plus.pid'
 WATCHDOG_TIMEOUT = 20.0  # seconds
 LOG_LEVEL = logging.DEBUG  # Changed to DEBUG for detailed EC port access logging
+SYSTEMD_FIRST_FD = 3
 
 
 class HelperDaemon:
@@ -58,6 +60,7 @@ class HelperDaemon:
         # Setup signal handlers
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
+        atexit.register(self.shutdown)
     
     def _signal_handler(self, signum, frame):
         """Handle termination signals"""
@@ -83,27 +86,21 @@ class HelperDaemon:
             self.logger.warning(f"Failed to remove PID file: {e}")
     
     def _create_socket(self):
-        """Create Unix domain socket"""
-        # Remove old socket if exists
-        if os.path.exists(self.socket_path):
-            os.remove(self.socket_path)
-        
-        self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.server_socket.bind(self.socket_path)
-        self.server_socket.listen(1)
-        
-        # Set permissions (readable/writable by all for simplicity)
-        os.chmod(self.socket_path, 0o666)
-        
-        self.logger.info(f"Listening on socket: {self.socket_path}")
+        """Use systemd socket activation only."""
+        listen_pid = os.environ.get('LISTEN_PID')
+        listen_fds = int(os.environ.get('LISTEN_FDS', '0'))
+
+        if not (listen_pid and int(listen_pid) == os.getpid() and listen_fds >= 1):
+            raise RuntimeError("Systemd socket activation not available (LISTEN_FDS/LISTEN_PID missing)")
+
+        self.server_socket = socket.socket(fileno=SYSTEMD_FIRST_FD)
+        self.logger.info(f"Using systemd-activated socket FD {SYSTEMD_FIRST_FD}")
     
     def _remove_socket(self):
-        """Remove socket file"""
+        """Close systemd-provided server socket."""
         try:
             if self.server_socket:
                 self.server_socket.close()
-            if os.path.exists(self.socket_path):
-                os.remove(self.socket_path)
             self.logger.info("Removed socket")
         except Exception as e:
             self.logger.warning(f"Failed to remove socket: {e}")
@@ -238,12 +235,6 @@ class HelperDaemon:
                 response['readback'] = f"0x{readback:02x}"
                 response['level'] = level
                 response['message'] = f'Brightness set to {level}' if success else f'Brightness set failed (readback mismatch)'
-            
-            elif cmd == 'shutdown':
-                response['success'] = True
-                response['message'] = 'Shutting down'
-                # Shutdown after sending response
-                threading.Timer(0.1, self.shutdown).start()
             
             else:
                 raise ValueError(f"Unknown command: {cmd}")
@@ -423,21 +414,30 @@ class HelperDaemon:
         sock.sendall(response_length + response_json)
     
     def shutdown(self):
-        """Shutdown the daemon"""
-        if not self.running:
-            return
-        
-        self.logger.info("Shutting down...")
+        """Shutdown the daemon (idempotent; always attempts cleanup)."""
+        was_running = self.running
         self.running = False
-        
+
+        if was_running:
+            self.logger.info("Shutting down...")
+        else:
+            self.logger.debug("Shutdown requested while not running; performing cleanup")
+
         # Cancel watchdog
-        self.watchdog.cancel()
-        
-        # Cleanup
-        self.cleanup_hardware()
+        try:
+            self.watchdog.cancel()
+        except Exception as e:
+            self.logger.debug(f"Watchdog cancel during shutdown failed: {e}")
+
+        # Cleanup resources even on early-startup failures
+        try:
+            self.cleanup_hardware()
+        except Exception as e:
+            self.logger.warning(f"Hardware cleanup failed: {e}")
+
         self._remove_socket()
         self._remove_pid_file()
-        
+
         self.logger.info("Shutdown complete")
 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ At the present time, Tinta4Plus only works on exactly the following system confi
 
 To run the app, simply cd into the extracted directory and execute: ./Tinta4Plus.py
 
+## Systemd socket-activated helper (recommended)
+
+Tinta4Plus now supports a systemd socket-activated privileged helper so normal app launches do not require runtime `pkexec` prompts.
+
+The app performs install/update flow directly when needed.
+
 ## Missing Features and Known Bugs
 - Display scaling is not being handeled correctly during switch, which also causes the eInk touch mapping to be off.
 - Haven't figured out how to change the eInk contrast yet.

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -24,10 +24,10 @@ import subprocess
 import sys
 import os
 import time
-import threading
 import logging
 import webbrowser
 import json
+import grp
 from datetime import datetime
 
 from HelperClient import HelperClient
@@ -169,7 +169,7 @@ class EInkControlGUI:
     VERSION = "0.1.0 alpha"
 
     # Configuration
-    SOCKET_PATH = '/tmp/tinta4plus.sock'
+    SOCKET_PATH = '/run/tinta4plus.sock'
     KEEPALIVE_INTERVAL = 2.4  # seconds (send keepalive every 2.4s, watchdog is 20s)
     SOCKET_TIMEOUT = 10.0  # seconds
     CONFIG_DIR = os.path.expanduser("~/.config/Tinta4Plus")
@@ -195,11 +195,11 @@ class EInkControlGUI:
         self.root = root
         self.root.title("ThinkBook E-Ink Control")
         self.root.geometry("600x700")
+        self._set_window_icon()
 
         # Helper client
         self.helper = HelperClient(logger)
         self.keepalive_after_id = None
-        self.helper_process = None
 
         # Managers
         self.display_mgr = DisplayManager(logger)
@@ -576,88 +576,141 @@ class EInkControlGUI:
     def show_info_dialog(self, message):
         """Show info dialog"""
         messagebox.showinfo("Information", message)
-    
-    def initialize_helper(self):
-        """Initialize connection to helper daemon"""
-        # First try to connect to existing helper
-        if os.path.exists(self.SOCKET_PATH):
-            try:
-                if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
-                    self.update_status("Connected to helper daemon")
-                    self.log_message("Connected to existing helper daemon")
-                    self.start_keepalive()
-                    return
-            except Exception as e:
-                self.log_message(f"Failed to connect to existing socket: {e}")
-                # Remove stale socket
-                try:
-                    os.remove(self.SOCKET_PATH)
-                except:
-                    pass
-        
-        # No existing helper, launch it
-        self.log_message("Helper daemon not found, launching...")
-        self.update_status("Launching helper daemon (password required)...")
-        
-        # Launch helper via pkexec in background
-        threading.Thread(target=self._launch_helper_thread, daemon=True).start()
-    
-    def _launch_helper_thread(self):
-        """Launch helper daemon in background thread"""
-        try:
-            # Determine helper script path
-            helper_path = self.HELPER_SCRIPT
-            
-            # If not installed, try relative to this script
-            if not os.path.exists(helper_path):
-                script_dir = os.path.dirname(os.path.abspath(__file__))
-                helper_path = os.path.join(script_dir, 'thinkbook-eink-helper.py')
-            
-            if not os.path.exists(helper_path):
-                self.root.after(0, self._helper_launch_failed, "Helper script not found")
-                return
-            
-            # Launch via pkexec (will show password prompt)
-            self.helper_process = subprocess.Popen(
-                ['pkexec', 'python3', helper_path],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
-            )
-            
-            # Wait a moment for helper to start
-            time.sleep(1.5)
-            
-            # Try to connect
-            max_attempts = 10
-            for attempt in range(max_attempts):
-                if os.path.exists(self.SOCKET_PATH):
-                    if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
-                        self.root.after(0, self._helper_launch_success)
-                        return
-                time.sleep(0.5)
-            
-            self.root.after(0, self._helper_launch_failed, 
-                          "Helper started but socket not available")
-            
-        except Exception as e:
-            self.root.after(0, self._helper_launch_failed, str(e))
-    
-    def _helper_launch_success(self):
-        """Called when helper successfully launched"""
-        self.update_status("Connected to helper daemon")
-        self.log_message("Helper daemon launched successfully")
-        self.start_keepalive()
 
-        # Check EC status
-        self.root.after(500, self.check_ec_status)
+    def _set_window_icon(self):
+        """Set window icon from common system icon paths if available."""
+        icon_candidates = [
+            "/usr/share/icons/elementary-xfce/apps/48/preferences-desktop-display.png",
+            "/usr/share/icons/HighContrast/48x48/apps/preferences-desktop-display.png",
+            "/usr/share/icons/HighContrast/32x32/apps/preferences-desktop-display.png",
+            "/usr/share/icons/hicolor/48x48/status/display-brightness.png",
+        ]
+
+        for icon_path in icon_candidates:
+            if os.path.exists(icon_path):
+                try:
+                    icon_image = tk.PhotoImage(file=icon_path)
+                    self.root.iconphoto(True, icon_image)
+                    self.root._tinta_icon_image = icon_image
+                    self.logger.info(f"Using window icon: {icon_path}")
+                    return
+                except Exception:
+                    continue
     
-    def _helper_launch_failed(self, error):
-        """Called when helper launch failed"""
-        self.update_status(f"Failed to launch helper: {error}", error=True)
-        self.log_message(f"ERROR: Failed to launch helper - {error}", level='error')
+    def _get_script_dir(self):
+        return os.path.dirname(os.path.abspath(__file__))
+
+    def _get_installer_path(self):
+        return os.path.join(self._get_script_dir(), 'scripts', 'install-systemd-helper-root.sh')
+
+    def _needs_helper_install_or_upgrade(self):
+        """Use installer --check mode to detect drift or missing setup."""
+        installer = self._get_installer_path()
+        if not os.path.exists(installer):
+            return True, f"Installer not found: {installer}"
+
+        user_name = os.environ.get('SUDO_USER') or os.environ.get('USER') or 'taras'
+        command = [installer, '--check', '--source-dir', self._get_script_dir(), '--user', user_name]
+        result = subprocess.run(command, capture_output=True, text=True)
+
+        if result.returncode == 0:
+            return False, None
+
+        if result.returncode == 1:
+            return True, None
+
+        details = (result.stderr or result.stdout or '').strip()
+        return True, details or f"Check failed with exit code {result.returncode}"
+
+    def _is_current_process_in_helper_group(self):
+        """Return True when this running process has tinta4plus group in its group list."""
+        try:
+            helper_group = grp.getgrnam('tinta4plus')
+        except KeyError:
+            return False
+
+        return helper_group.gr_gid in os.getgroups()
+
+    def _run_helper_installer(self):
+        installer = self._get_installer_path()
+        if not os.path.exists(installer):
+            return False, f"Installer not found: {installer}"
+
+        user_name = os.environ.get('SUDO_USER') or os.environ.get('USER') or 'taras'
+        command = ['pkexec', installer, '--user', user_name, '--source-dir', self._get_script_dir()]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or '').strip()
+            return False, details or f"Installer failed with exit code {result.returncode}"
+
+        return True, None
+
+    def _prompt_install_or_upgrade(self):
+        needs_install, check_error = self._needs_helper_install_or_upgrade()
+        if check_error:
+            self.log_message(f"WARNING: Helper check failed: {check_error}", level='warning')
+
+        if not needs_install and self._is_current_process_in_helper_group():
+            return True
+
+        if needs_install:
+            prompt = (
+                "Tinta4Plus needs to install or update the system helper service.\n\n"
+                "This is a one-time privileged action using pkexec.\n"
+                "Install now?"
+            )
+        else:
+            prompt = (
+                "Your user is not active in the 'tinta4plus' group in this session.\n\n"
+                "Tinta4Plus can refresh permissions via installer now, then you'll need to re-login\n"
+                "and restart the app. Continue?"
+            )
+
+        install_now = messagebox.askyesno("Install privileged helper", prompt)
+        if not install_now:
+            return False
+
+        self.update_status("Installing/updating helper service (password required)...")
+        self.log_message("Installing/updating helper service via pkexec...")
+        ok, error = self._run_helper_installer()
+        if not ok:
+            self.log_message(f"ERROR: Helper install failed - {error}", level='error')
+            self.show_error_dialog(f"Helper install failed:\n\n{error}")
+            return False
+
+        if not self._is_current_process_in_helper_group():
+            self.show_info_dialog(
+                "Helper service installed/updated.\n\n"
+                "You must log out and log back in (or run 'newgrp tinta4plus' from a shell)\n"
+                "then restart Tinta4Plus."
+            )
+            self.log_message("Group membership update requires re-login before reconnect", level='warning')
+            return False
+
+        self.log_message("✓ Helper service installed/updated")
+        return True
+
+    def initialize_helper(self):
+        """Initialize connection to systemd socket-activated helper daemon."""
+        if not self._prompt_install_or_upgrade():
+            self.update_status("Helper service not installed")
+            return
+
+        try:
+            if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
+                self.update_status("Connected to helper daemon")
+                self.log_message("Connected to helper daemon")
+                self.start_keepalive()
+                self.root.after(500, self.check_ec_status)
+                return
+        except Exception as e:
+            self.log_message(f"Failed to connect to helper socket: {e}", level='error')
+
+        self.update_status("Failed to connect to helper daemon", error=True)
         self.show_error_dialog(
-            f"Failed to launch helper daemon:\n\n{error}\n\n"
-            "Make sure you entered the correct password."
+            "Could not connect to helper daemon at /run/tinta4plus.sock.\n\n"
+            "Run installer or check:\n"
+            "  systemctl status tinta4plus-helper.socket"
         )
     
     def start_keepalive(self):
@@ -713,51 +766,39 @@ class EInkControlGUI:
             self.attempt_helper_restart()
     
     def attempt_helper_restart(self):
-        """Attempt to restart the helper daemon with better error recovery"""
-        # Cancel any existing keepalive
+        """Attempt to reconnect to systemd socket-activated helper."""
         if self.keepalive_after_id:
             self.root.after_cancel(self.keepalive_after_id)
             self.keepalive_after_id = None
-        
-        self.log_message("Attempting to restart helper daemon...")
-        
-        # Disconnect cleanly first
+
+        self.log_message("Attempting to reconnect to helper daemon...")
+
         try:
             if self.helper.is_connected():
                 self.helper.disconnect()
         except Exception as e:
             self.logger.debug(f"Error during disconnect: {e}")
-        
-        # Small delay to allow cleanup
+
         time.sleep(0.5)
-        
-        # Try to connect to existing socket first
-        if os.path.exists(self.SOCKET_PATH):
-            try:
-                if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
-                    self.log_message("✓ Reconnected to existing helper")
-                    self.update_status("Reconnected to helper daemon")
-                    self.start_keepalive()
-                    # Re-check EC status and sync frontlight state after reconnect
-                    self.root.after(500, self.check_ec_status)
-                    return
-            except Exception as e:
-                self.logger.debug(f"Failed to reconnect to existing socket: {e}")
-                # Get detailed error from helper client
-                last_error = self.helper.get_last_error()
-                if last_error:
-                    self.log_message(f"Connection error: {last_error}", level='error')
-                # Remove stale socket
-                try:
-                    os.remove(self.SOCKET_PATH)
-                    self.log_message("Removed stale socket file")
-                except Exception as e:
-                    self.logger.warning(f"Could not remove socket: {e}")
-        
-        # Need to launch new helper
-        self.log_message("Launching new helper daemon (password may be required)...")
-        self.update_status("Launching helper daemon...")
-        threading.Thread(target=self._launch_helper_thread, daemon=True).start()
+
+        try:
+            if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
+                self.log_message("✓ Reconnected to helper daemon")
+                self.update_status("Reconnected to helper daemon")
+                self.start_keepalive()
+                self.root.after(500, self.check_ec_status)
+                return
+        except Exception as e:
+            self.logger.debug(f"Failed to reconnect helper socket: {e}")
+
+        self.log_message("ERROR: Helper reconnection failed", level='error')
+        self.update_status("Helper disconnected", error=True)
+        self.show_error_dialog(
+            "Lost connection to helper daemon.\n\n"
+            "Check service status:\n"
+            "  systemctl status tinta4plus-helper.socket\n"
+            "  systemctl status tinta4plus-helper.service"
+        )
     
     def check_ec_status(self):
         """Check EC access status and disable frontlight controls if Secure Boot enabled"""
@@ -1218,17 +1259,9 @@ class EInkControlGUI:
         if self.keepalive_after_id:
             self.root.after_cancel(self.keepalive_after_id)
 
-        # Disconnect from helper (sends shutdown command)
+        # Disconnect from helper client socket
         if self.helper.is_connected():
             self.helper.disconnect()
-
-        # Terminate helper process if we launched it
-        if self.helper_process:
-            try:
-                self.helper_process.terminate()
-                self.helper_process.wait(timeout=2)
-            except:
-                pass
 
         self.root.destroy()
 
@@ -1407,7 +1440,7 @@ def show_disclaimer_dialog(parent=None):
 
 def main():
     """Entry point"""
-    HELPER_SCRIPT = '/usr/local/bin/HelperDaemon.py'  # Or use sys.argv[0] relative path
+    HELPER_SCRIPT = '/usr/local/lib/tinta4plus/HelperDaemon.py'
 
     # Setup logging
     log_handlers = [
@@ -1434,15 +1467,6 @@ def main():
 
     sys.excepthook = handle_exception
 
-    # Check if helper script exists
-    if not os.path.exists(HELPER_SCRIPT):
-        # Try relative path
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        alt_helper = os.path.join(script_dir, 'HelperDaemon.py')
-        if os.path.exists(alt_helper):
-            HELPER_SCRIPT = alt_helper
-            logger.info(f"Using helper at: {HELPER_SCRIPT}")
-    
     root = tk.Tk()
     root.withdraw()  # Hide the main window initially
 

--- a/contrib/systemd/tinta4plus-helper.service
+++ b/contrib/systemd/tinta4plus-helper.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Tinta4Plus privileged helper daemon
+Requires=tinta4plus-helper.socket
+After=tinta4plus-helper.socket
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/lib/tinta4plus/HelperDaemon.py
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/tinta4plus-helper.socket
+++ b/contrib/systemd/tinta4plus-helper.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tinta4Plus privileged helper socket
+
+[Socket]
+ListenStream=/run/tinta4plus.sock
+SocketMode=0660
+SocketGroup=tinta4plus
+RemoveOnStop=yes
+
+[Install]
+WantedBy=sockets.target

--- a/docs/plans/2026-03-01-systemd-socket-activation-design.md
+++ b/docs/plans/2026-03-01-systemd-socket-activation-design.md
@@ -1,0 +1,115 @@
+# Systemd Socket Activation for Tinta4Plus Helper (Design)
+
+**Date:** 2026-03-01  
+**Branch:** `taras/fixes`
+
+## Goal
+Replace runtime `pkexec` helper launch with a systemd socket-activated root helper so the GUI connects reliably without auth timing races, while keeping a `pkexec` path for one-time installation/bootstrap.
+
+## Current Problem Summary
+- GUI currently starts helper via `pkexec` and then waits for `/tmp/tinta4plus.sock`.
+- User auth delay and helper startup timing can produce false-negative launch failures.
+- Runtime auth prompt is fragile UX and hard to reason about.
+
+## Target Architecture
+
+### Runtime (normal use)
+1. GUI connects to `/run/tinta4plus.sock`.
+2. `tinta4plus-helper.socket` is active and owns that socket.
+3. On first connection, systemd activates `tinta4plus-helper.service` as root.
+4. Helper serves requests over the inherited socket (systemd socket activation path).
+5. No runtime `pkexec` prompt.
+
+### Bootstrap/install (one-time or upgrade)
+1. User runs install command/script.
+2. Install uses `pkexec` for privileged steps only.
+3. Installer places helper binary and unit files, configures permissions/group, enables socket unit.
+
+## Security Model
+- Socket path: `/run/tinta4plus.sock`
+- Socket permissions: `0660`
+- Socket group: `tinta4plus`
+- Access control: only users in `tinta4plus` group can open socket.
+- Helper remains root and must validate all command inputs and ranges.
+- Optional hardening: peer credential check (`SO_PEERCRED`) to restrict allowed UIDs.
+
+## Proposed File Changes
+
+### New files
+- `contrib/systemd/tinta4plus-helper.socket`
+- `contrib/systemd/tinta4plus-helper.service`
+
+### Modified files
+- `HelperDaemon.py`
+  - Add support for inherited systemd socket FD (`LISTEN_FDS` flow).
+  - Keep fallback bind/listen behavior for manual/dev mode.
+  - is launched directly by unit
+- `Tinta4Plus.py`
+  - Prefer `/run/tinta4plus.sock`.
+  - remove all code with old `/tmp/tinta4plus.sock`  legacy mode.
+  - Adjust helper initialization flow to avoid runtime `pkexec` when systemd socket mode is available. eg instead offer to install daemon and user for it add current user to the group..use pkexec for that once user says ye
+  - during helper connection, check if the installed service is older than the HelperDaemon.py next to Tinata4Plus.py..then also run  the install workflow via pkexecs
+- `README.md`
+  - Document installation, group membership, and verification commands.
+
+## Unit Definitions (intent)
+
+### `tinta4plus-helper.socket`
+- Listens on Unix socket `/run/tinta4plus.sock`
+- `SocketMode=0660`
+- `SocketGroup=tinta4plus`
+- Activated at boot (`WantedBy=sockets.target`)
+
+### `tinta4plus-helper.service`
+- Runs helper as root
+- Started by socket activation (no need for manual start)
+- Uses installed helper path (e.g., `/usr/local/bin/HelperDaemon.py`)
+- Restart policy conservative (e.g., `Restart=on-failure`)
+
+## Installer Responsibilities
+
+### User entrypoint (`install-systemd-helper.sh`)
+- Presents friendly output for success/failure and post-install steps.
+
+### Root installer (`install-systemd-helper-root.sh`)
+- Ensure `tinta4plus` group exists.
+- Add invoking user to `tinta4plus` group (if desired and safe).
+- Install helper to `/usr/local/bin/HelperDaemon.py` with executable perms.
+- Install unit files into `/etc/systemd/system/`.
+- `systemctl daemon-reload`
+- `systemctl enable --now tinta4plus-helper.socket`
+- restart unit in case it was installed before
+
+## Migration / Compatibility Strategy
+- No legacy path.
+- Remove all manual/debug-mode artifacts and assumptions:
+  - remove `shutdown` command usage from GUI/client disconnect flow
+  - remove helper protocol `shutdown` command handler
+  - remove fallback/manual socket bind mode in helper (systemd socket activation only)
+  - remove any `/tmp/tinta4plus.sock` references
+  - remove any runtime `pkexec` helper-launch logic (install/update only)
+
+## Verification Plan
+1. Install via new installer script.
+2. Confirm socket unit active:
+   - `systemctl status tinta4plus-helper.socket`
+3. Confirm socket exists with correct mode/group:
+   - `ls -l /run/tinta4plus.sock`
+4. Launch GUI and ASK USER TO verify no runtime auth prompt.
+5. Confirm helper starts on first connection:
+   - `systemctl status tinta4plus-helper.service`
+6. Exercise key commands (enable/disable/refresh/frontlight).
+7. Confirm reconnection behavior after helper restart.
+
+## Risks and Mitigations
+- **Group membership not applied until new login**
+  - Mitigation: document re-login/newgrp requirement.
+- **Permission misconfiguration on `/run` socket**
+  - Mitigation: explicit unit settings + install-time checks.
+
+## Execution Order
+0. Undo prior pkexec startup-hardening patch first (restore baseline before systemd migration).
+1. Add units + installer.
+2. Add helper socket-activation support.
+3. Switch GUI to `/run/tinta4plus.sock` and remove runtime pkexec launch path.
+4. Validate end-to-end.

--- a/review.md
+++ b/review.md
@@ -1,0 +1,69 @@
+# Branch Review (`pr-1..HEAD`)
+
+## Scope
+Reviewed all 13 commits from `pr-1` to `HEAD` on `taras/fixes`.
+
+## Summary
+Overall direction is good. Migrating from ad-hoc `pkexec` helper startup to systemd socket activation improves reliability and security posture.
+
+---
+
+## Findings
+
+### 1) High — installer can run with empty `--user`
+**File:** `scripts/install-systemd-helper-root.sh`
+
+`USER_NAME` defaults to empty, but install mode always runs:
+
+```bash
+usermod -a -G tinta4plus "$USER_NAME"
+```
+
+If `--user` is omitted/empty, install fails unpredictably.
+
+**Recommendation:**
+Fail early in install mode when `--user` is empty, with a clear error message.
+
+---
+
+### 2) Medium — stale PID file possible on early startup failure
+**File:** `HelperDaemon.py`
+
+`run()` creates PID file before `_create_socket()`. If `_create_socket()` fails (e.g., missing `LISTEN_FDS`/`LISTEN_PID`), `finally: shutdown()` is called, but `shutdown()` returns immediately when `self.running` is `False`, leaving PID file behind.
+
+**Recommendation:**
+Use a trap-like cleanup approach in Python: make `shutdown()` idempotent and always perform cleanup (PID/socket removal, watchdog cancel, hardware cleanup) even when `self.running` was never set to `True`. Optionally also register cleanup with `atexit` for extra safety.
+
+---
+
+### 3) Low — outdated comment
+**File:** `Tinta4Plus.py` (`on_closing`)
+
+Comment says disconnect “sends shutdown command”, but shutdown command behavior was intentionally removed.
+
+**Recommendation:**
+Update comment to reflect current behavior.
+
+---
+
+### 4) Low — desktop launcher tied to checkout path
+**File:** `scripts/install-systemd-helper-root.sh`
+
+Desktop file uses:
+- `Exec=$APP_MAIN`
+- `Path=$SOURCE_DIR`
+
+This ties launcher validity to the original source directory.
+
+**Recommendation:**
+Use a stable launcher/entrypoint and reference it from the `.desktop` file. In Python, resolve paths relative to the script file (the `$0` equivalent) using `Path(__file__).resolve().parent` (or `os.path.dirname(os.path.abspath(__file__))`) so runtime behavior does not depend on the current working directory.
+
+---
+
+## Positive notes
+
+- Socket migrated to `/run/tinta4plus.sock` with `0660` and `SocketGroup=tinta4plus`.
+- Client no longer tries to shut down daemon directly (correct for socket activation).
+- Added installer drift detection via `--check`.
+- GUI install/upgrade flow and group-membership handling are sensible.
+- Python changed files compile cleanly.

--- a/scripts/install-systemd-helper-root.sh
+++ b/scripts/install-systemd-helper-root.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="install"
+USER_NAME=""
+SOURCE_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --user)
+      USER_NAME="${2:-}"
+      shift 2
+      ;;
+    --source-dir)
+      SOURCE_DIR="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$SOURCE_DIR" ]]; then
+  echo "Usage: $0 [--check] --source-dir <path> [--user <username>]" >&2
+  exit 2
+fi
+
+if [[ "$MODE" == "install" && $EUID -ne 0 ]]; then
+  echo "This script must run as root" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "install" && -z "$USER_NAME" ]]; then
+  echo "Install mode requires --user <username>" >&2
+  exit 2
+fi
+
+HELPER_SRC="$SOURCE_DIR/HelperDaemon.py"
+WATCHDOG_SRC="$SOURCE_DIR/WatchdogTimer.py"
+EC_SRC="$SOURCE_DIR/ECController.py"
+EINK_SRC="$SOURCE_DIR/EInkUSBController.py"
+SOCKET_UNIT_SRC="$SOURCE_DIR/contrib/systemd/tinta4plus-helper.socket"
+SERVICE_UNIT_SRC="$SOURCE_DIR/contrib/systemd/tinta4plus-helper.service"
+INSTALL_DIR="/usr/local/lib/tinta4plus"
+DESKTOP_FILE="/usr/share/applications/eink-tinta4plus.desktop"
+APP_MAIN="$SOURCE_DIR/Tinta4Plus.py"
+
+[[ -f "$HELPER_SRC" ]] || { echo "Missing $HELPER_SRC" >&2; exit 1; }
+[[ -f "$WATCHDOG_SRC" ]] || { echo "Missing $WATCHDOG_SRC" >&2; exit 1; }
+[[ -f "$EC_SRC" ]] || { echo "Missing $EC_SRC" >&2; exit 1; }
+[[ -f "$EINK_SRC" ]] || { echo "Missing $EINK_SRC" >&2; exit 1; }
+[[ -f "$SOCKET_UNIT_SRC" ]] || { echo "Missing $SOCKET_UNIT_SRC" >&2; exit 1; }
+[[ -f "$SERVICE_UNIT_SRC" ]] || { echo "Missing $SERVICE_UNIT_SRC" >&2; exit 1; }
+[[ -f "$APP_MAIN" ]] || { echo "Missing $APP_MAIN" >&2; exit 1; }
+
+pick_icon_path() {
+  local candidates=(
+    "/usr/share/icons/elementary-xfce/apps/48/preferences-desktop-display.png"
+    "/usr/share/icons/HighContrast/48x48/apps/preferences-desktop-display.png"
+    "/usr/share/icons/HighContrast/32x32/apps/preferences-desktop-display.png"
+    "/usr/share/icons/hicolor/48x48/status/display-brightness.png"
+  )
+
+  for icon in "${candidates[@]}"; do
+    if [[ -f "$icon" ]]; then
+      echo "$icon"
+      return 0
+    fi
+  done
+
+  echo "video-display-symbolic"
+}
+
+write_desktop_file() {
+  local icon="$1"
+  cat > "$2" <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=EInk-Tinta4+
+Comment=Control ThinkBook Plus E-Ink display
+Exec=$APP_MAIN
+TryExec=$APP_MAIN
+Path=$SOURCE_DIR
+Icon=$icon
+Terminal=false
+Categories=System;
+StartupNotify=true
+EOF
+}
+
+if [[ "$MODE" == "check" ]]; then
+  status=0
+
+  check_same() {
+    local src="$1"
+    local dst="$2"
+    if [[ ! -f "$dst" ]] || ! cmp -s "$src" "$dst"; then
+      status=1
+    fi
+  }
+
+  check_same "$HELPER_SRC" "$INSTALL_DIR/HelperDaemon.py"
+  check_same "$WATCHDOG_SRC" "$INSTALL_DIR/WatchdogTimer.py"
+  check_same "$EC_SRC" "$INSTALL_DIR/ECController.py"
+  check_same "$EINK_SRC" "$INSTALL_DIR/EInkUSBController.py"
+  check_same "$SOCKET_UNIT_SRC" "/etc/systemd/system/tinta4plus-helper.socket"
+  check_same "$SERVICE_UNIT_SRC" "/etc/systemd/system/tinta4plus-helper.service"
+
+  tmp_desktop="$(mktemp)"
+  write_desktop_file "$(pick_icon_path)" "$tmp_desktop"
+  check_same "$tmp_desktop" "$DESKTOP_FILE"
+  rm -f "$tmp_desktop"
+
+  if ! getent group tinta4plus >/dev/null; then
+    status=1
+  fi
+
+  if [[ -n "$USER_NAME" ]] && ! id -nG "$USER_NAME" | tr ' ' '\n' | grep -qx tinta4plus; then
+    status=1
+  fi
+
+  if ! systemctl is-enabled tinta4plus-helper.socket >/dev/null 2>&1; then
+    status=1
+  fi
+
+  exit $status
+fi
+
+install -d -m 0755 "$INSTALL_DIR"
+install -m 0644 "$HELPER_SRC" "$INSTALL_DIR/HelperDaemon.py"
+install -m 0644 "$WATCHDOG_SRC" "$INSTALL_DIR/WatchdogTimer.py"
+install -m 0644 "$EC_SRC" "$INSTALL_DIR/ECController.py"
+install -m 0644 "$EINK_SRC" "$INSTALL_DIR/EInkUSBController.py"
+rm -f /usr/local/bin/HelperDaemon.py
+install -m 0644 "$SOCKET_UNIT_SRC" /etc/systemd/system/tinta4plus-helper.socket
+install -m 0644 "$SERVICE_UNIT_SRC" /etc/systemd/system/tinta4plus-helper.service
+write_desktop_file "$(pick_icon_path)" "$DESKTOP_FILE"
+chmod 0644 "$DESKTOP_FILE"
+
+if ! getent group tinta4plus >/dev/null; then
+  groupadd --system tinta4plus
+fi
+
+usermod -a -G tinta4plus "$USER_NAME"
+
+systemctl daemon-reload
+systemctl stop tinta4plus-helper.service tinta4plus-helper.socket 2>/dev/null || true
+systemctl reset-failed tinta4plus-helper.service tinta4plus-helper.socket 2>/dev/null || true
+rm -f /run/tinta4plus.sock /tmp/tinta4plus.pid
+systemctl enable --now tinta4plus-helper.socket
+systemctl restart tinta4plus-helper.socket
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+
+echo "Installed and enabled tinta4plus-helper.socket"
+echo "Installed desktop launcher: $DESKTOP_FILE"
+echo "User '$USER_NAME' added to group 'tinta4plus' (re-login may be required)."


### PR DESCRIPTION
I slop-coded a different way to use root part. I think this is more Linuxy and  more reliable. We now have a socket-activated server part that only launches when  needed