### PR TITLE
socket-activated helper, shared mode-switching, and wakeup reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local git worktrees
+.worktrees/

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -13,6 +13,7 @@ import subprocess
 import os
 import re
 import time
+import math
 
 
 class DisplayManager:
@@ -217,8 +218,8 @@ class DisplayManager:
         xrandr_scale_x = 1.0 / requested_scale
         xrandr_scale_y = 1.0 / requested_scale
 
-        logical_width = max(1, int(native_width * xrandr_scale_x))
-        logical_height = max(1, int(native_height * xrandr_scale_y))
+        logical_width = max(1, math.ceil(native_width * xrandr_scale_x))
+        logical_height = max(1, math.ceil(native_height * xrandr_scale_y))
 
         return {
             'display_name': display_name,
@@ -337,12 +338,11 @@ class DisplayManager:
         fb_height = actual['framebuffer_height']
         if fb_width is None or fb_height is None:
             mismatches['framebuffer'] = {'expected': 'present', 'actual': None}
-        else:
-            if fb_width < expected_width or fb_height < expected_height:
-                mismatches['framebuffer_too_small'] = {
-                    'expected_min': f"{expected_width}x{expected_height}",
-                    'actual': f"{fb_width}x{fb_height}",
-                }
+        elif fb_width != expected_width or fb_height != expected_height:
+            mismatches['framebuffer_size'] = {
+                'expected': f"{expected_width}x{expected_height}",
+                'actual': f"{fb_width}x{fb_height}",
+            }
 
         if actual['output_width'] != expected_width or actual['output_height'] != expected_height:
             mismatches['output_geometry'] = {
@@ -385,46 +385,40 @@ class DisplayManager:
         cmd = ['xrandr', '--output', display_name, '--auto']
         return self._run_xrandr_apply_command(display_name, cmd)
 
+    def _activate_display_transition_safe(self, display_name, scale=None):
+        """Activate output without forcing a compact single-output framebuffer."""
+        target_state = self._build_display_target_state(display_name, scale)
+        if not target_state:
+            self.logger.warning(f"Unknown display {display_name}, using auto mode")
+            return self._run_xrandr_apply_command(display_name, ['xrandr', '--output', display_name, '--auto'])
+
+        scale_x = target_state['xrandr_scale_x']
+        scale_y = target_state['xrandr_scale_y']
+        scale_text = '1x1' if scale_x == 1.0 and scale_y == 1.0 else f'{scale_x}x{scale_y}'
+
+        cmd = [
+            'xrandr', '--output', display_name,
+            '--mode', f"{target_state['native_width']}x{target_state['native_height']}",
+            '--scale', scale_text,
+        ]
+        return self._run_xrandr_apply_command(display_name, cmd)
+
     def enable_display(self, display_name, scale=None):
         """Enable/turn on a display with optional scaling.
 
         Args:
             display_name: Name of the display (e.g., 'eDP-1', 'eDP-2')
             scale: Optional scale factor (e.g., 1.60 means UI appears 1.6x larger, lower DPI)
-                   Uses xrandr --scale with --panning and --fb for full-state transitions.
         """
         try:
-            target_state = self._build_display_target_state(display_name, scale)
-
-            if not self._apply_display_scale(display_name, scale):
+            if not self._activate_display_transition_safe(display_name, scale):
                 return False
 
             self._xrandr_cache = None
             time.sleep(self.XRANDR_APPLY_DELAY)
 
-            verified = True
-            if target_state:
-                verified = self._verify_display_target_state(display_name, target_state)
-                if not verified:
-                    self.logger.warning(
-                        f"Post-apply verification failed for {display_name}; running one recovery attempt"
-                    )
-                    if not self._reset_display_to_native_baseline(display_name):
-                        return False
-                    if not self._apply_display_target_state(target_state):
-                        return False
-
-                    self._xrandr_cache = None
-                    time.sleep(self.XRANDR_APPLY_DELAY)
-                    verified = self._verify_display_target_state(display_name, target_state)
-            else:
-                verified = self.is_display_active(display_name)
-
-            if not verified:
-                self.logger.error(
-                    f"Failed to enable display: {display_name} "
-                    "(verification mismatch after one recovery attempt)"
-                )
+            if not self.is_display_active(display_name):
+                self.logger.error(f"Failed to enable display: {display_name} (display not active after apply)")
                 return False
 
             scale_info = f" with {scale}x scale" if scale and scale != 1.0 else ""
@@ -450,6 +444,33 @@ class DisplayManager:
 
         except Exception as e:
             self.logger.error(f"Failed to enable display: {e}")
+            return False
+    def finalize_single_display(self, display_name, scale=None):
+        """Apply and verify the final compact single-output RandR state."""
+        try:
+            target_state = self._build_display_target_state(display_name, scale)
+            if not target_state:
+                self.logger.error(f"Cannot finalize unknown display: {display_name}")
+                return False
+
+            self.logger.info(f"Finalizing single-display layout for {display_name}: {target_state}")
+            if not self._apply_display_target_state(target_state):
+                return False
+
+            self._xrandr_cache = None
+            time.sleep(self.XRANDR_APPLY_DELAY)
+
+            if not self._verify_display_target_state(display_name, target_state):
+                self.logger.error(f"Failed to finalize single-display layout for {display_name}")
+                return False
+
+            self.logger.info(
+                f"Finalized single-display layout for {display_name}: "
+                f"{target_state['logical_width']}x{target_state['logical_height']}"
+            )
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to finalize display layout: {e}")
             return False
     
     def disable_display(self, display_name):

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -20,59 +20,87 @@ class DisplayManager:
     # ThinkBook Plus Gen 4 IRU hardware specifications
     OLED_RESOLUTION_WH = [2880, 1800]
     EINK_RESOLUTION_WH = [2560, 1600]
+    
+    # Display name to resolution mapping for easy extension
+    DISPLAY_RESOLUTIONS = {
+        'eDP-1': [2880, 1800],  # OLED
+        'eDP-2': [2560, 1600],  # E-Ink
+    }
+    
+    # Timing constants (seconds)
+    XRANDR_APPLY_DELAY = 0.2
+    IMAGE_DISPLAY_DELAY = 0.5
+    XRANDR_TIMEOUT = 5
+    WHICH_TIMEOUT = 2
+    
+    # Cache timeout for xrandr queries (seconds)
+    XRANDR_CACHE_TTL = 0.5
 
     def __init__(self, logger):
         self.logger = logger
+        self._xrandr_cache = None
+        self._xrandr_cache_time = 0
+    
+    def _get_xrandr_output(self):
+        """Get cached xrandr output to reduce subprocess overhead"""
+        current_time = time.time()
+        if self._xrandr_cache is not None and (current_time - self._xrandr_cache_time) < self.XRANDR_CACHE_TTL:
+            return self._xrandr_cache
+        
+        try:
+            result = subprocess.run(
+                ['xrandr', '--query'],
+                capture_output=True,
+                text=True,
+                timeout=self.XRANDR_TIMEOUT
+            )
+            
+            if result.returncode != 0:
+                self.logger.error(f"xrandr error: {result.stderr}")
+                return None
+            
+            self._xrandr_cache = result.stdout
+            self._xrandr_cache_time = current_time
+            return result.stdout
+            
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"xrandr query timed out after {self.XRANDR_TIMEOUT}s")
+            return None
+        except Exception as e:
+            self.logger.error(f"Failed to query xrandr: {e}")
+            return None
     
     def get_displays(self):
         """Get list of connected displays using xrandr"""
-        try:
-            result = subprocess.run(
-                ['xrandr', '--query'],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-            
-            displays = []
-            for line in result.stdout.split('\n'):
-                if ' connected' in line:
-                    parts = line.split()
-                    name = parts[0]
-                    primary = 'primary' in line
-                    displays.append({'name': name, 'primary': primary})
-            
-            return displays
-            
-        except Exception as e:
-            self.logger.error(f"Failed to get displays: {e}")
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
             return []
+        
+        displays = []
+        for line in xrandr_output.split('\n'):
+            if ' connected' in line:
+                parts = line.split()
+                name = parts[0]
+                primary = 'primary' in line
+                displays.append({'name': name, 'primary': primary})
+        
+        return displays
     
     def is_display_active(self, display_name):
         """Check if a display is currently active (enabled and has geometry)"""
-        try:
-            result = subprocess.run(
-                ['xrandr', '--query'],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-
-            for line in result.stdout.split('\n'):
-                if display_name in line and ' connected' in line:
-                    parts = line.split()
-                    # Display is active if it has geometry info (e.g., 1920x1080+0+0)
-                    # Look for pattern like "1920x1080+0+0" in the line
-                    for part in parts:
-                        if 'x' in part and '+' in part:
-                            return True
-                    return False
-
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
             return False
-
-        except Exception as e:
-            self.logger.error(f"Failed to check display status: {e}")
-            return False
+        
+        for line in xrandr_output.split('\n'):
+            if display_name in line and ' connected' in line:
+                # Display is active if it has geometry info (e.g., 1920x1080+0+0)
+                for part in line.split():
+                    if 'x' in part and '+' in part:
+                        return True
+                return False
+        
+        return False
 
     def enable_display(self, display_name, scale=None):
         """Enable/turn on a display with optional scaling
@@ -84,12 +112,9 @@ class DisplayManager:
                    This keeps touch input properly mapped.
         """
         try:
-            # Determine native resolution based on display name
-            # eDP-1 is OLED, eDP-2 is E-Ink on ThinkBook Plus Gen 4
-            if display_name == "eDP-1":
-                native_width, native_height = self.OLED_RESOLUTION_WH
-            elif display_name == "eDP-2":
-                native_width, native_height = self.EINK_RESOLUTION_WH
+            # Determine native resolution from display name mapping
+            if display_name in self.DISPLAY_RESOLUTIONS:
+                native_width, native_height = self.DISPLAY_RESOLUTIONS[display_name]
             else:
                 self.logger.warning(f"Unknown display {display_name}, using auto mode")
                 native_width, native_height = None, None
@@ -129,15 +154,24 @@ class DisplayManager:
                 cmd.append('--auto')
 
             # Run xrandr command (may produce spurious BadMatch errors on stderr)
-            subprocess.run(
-                cmd,
-                capture_output=True,
-                timeout=5
-            )
-
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    timeout=self.XRANDR_TIMEOUT
+                )
+                if result.returncode != 0:
+                    self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
+            except subprocess.TimeoutExpired:
+                self.logger.error(f"xrandr enable command timed out after {self.XRANDR_TIMEOUT}s")
+                return False
+            
+            # Invalidate cache since display state changed
+            self._xrandr_cache = None
+            
             # Verify the display is actually enabled by checking its state
             # Give X11 a moment to apply the change
-            time.sleep(0.2)
+            time.sleep(self.XRANDR_APPLY_DELAY)
 
             if self.is_display_active(display_name):
                 scale_info = f" with {scale}x scale" if scale and scale != 1.0 else ""
@@ -155,15 +189,24 @@ class DisplayManager:
         """Disable/turn off a display"""
         try:
             # Run xrandr command (may produce spurious BadMatch errors on stderr)
-            subprocess.run(
-                ['xrandr', '--output', display_name, '--off'],
-                capture_output=True,
-                timeout=5
-            )
-
+            try:
+                result = subprocess.run(
+                    ['xrandr', '--output', display_name, '--off'],
+                    capture_output=True,
+                    timeout=self.XRANDR_TIMEOUT
+                )
+                if result.returncode != 0:
+                    self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
+            except subprocess.TimeoutExpired:
+                self.logger.error(f"xrandr disable command timed out after {self.XRANDR_TIMEOUT}s")
+                return False
+            
+            # Invalidate cache since display state changed
+            self._xrandr_cache = None
+            
             # Verify the display is actually disabled by checking its state
             # Give X11 a moment to apply the change
-            time.sleep(0.2)
+            time.sleep(self.XRANDR_APPLY_DELAY)
 
             if not self.is_display_active(display_name):
                 self.logger.info(f"Disabled display: {display_name}")
@@ -179,16 +222,13 @@ class DisplayManager:
     def get_display_geometry(self, display_name):
         """Get the geometry (position and size) of a display using xrandr"""
         try:
-            result = subprocess.run(
-                ['xrandr', '--query'],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
+            xrandr_output = self._get_xrandr_output()
+            if not xrandr_output:
+                return None
 
             # Parse xrandr output to find the display geometry
             # Format: "eDP-2 connected 1200x1920+1920+0 ..."
-            for line in result.stdout.split('\n'):
+            for line in xrandr_output.split('\n'):
                 if display_name in line and 'connected' in line:
                     # Look for the geometry pattern: WIDTHxHEIGHT+X+Y
                     parts = line.split()
@@ -258,7 +298,7 @@ class DisplayManager:
                 process = subprocess.Popen(cmd)
 
                 # Give it a moment to display
-                time.sleep(0.5)
+                time.sleep(self.IMAGE_DISPLAY_DELAY)
 
                 return process
 
@@ -278,7 +318,7 @@ class DisplayManager:
                 self.logger.warning("imv may not position on correct display automatically")
                 process = subprocess.Popen(cmd)
 
-                time.sleep(0.5)
+                time.sleep(self.IMAGE_DISPLAY_DELAY)
                 return process
 
             except Exception as e:
@@ -299,8 +339,11 @@ class DisplayManager:
                 ['which', command],
                 capture_output=True,
                 check=True,
-                timeout=2
+                timeout=self.WHICH_TIMEOUT
             )
             return True
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        except subprocess.CalledProcessError:
+            return False
+        except subprocess.TimeoutExpired:
+            self.logger.warning(f"Command check for '{command}' timed out")
             return False

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -11,6 +11,7 @@ By downloading and using this software you agree to these terms and acknowledge 
 
 import subprocess
 import os
+import re
 import time
 
 
@@ -35,6 +36,9 @@ class DisplayManager:
     
     # Cache timeout for xrandr queries (seconds)
     XRANDR_CACHE_TTL = 0.5
+
+    SUPPORTED_ROTATIONS = {"normal", "left"}
+    XRANDR_ROTATIONS = {"normal", "left", "right", "inverted"}
 
     def __init__(self, logger):
         self.logger = logger
@@ -101,6 +105,66 @@ class DisplayManager:
                 return False
         
         return False
+
+    def get_active_display(self):
+        """Return currently active connected display name, or None."""
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
+            return None
+
+        for line in xrandr_output.split('\n'):
+            if ' connected' not in line:
+                continue
+            parts = line.split()
+            if not parts:
+                continue
+            if any(re.match(r"^\d+x\d+\+\d+\+\d+$", part) for part in parts):
+                return parts[0]
+
+        return None
+
+    def get_display_rotation(self, display_name):
+        """Return raw xrandr rotation for display when supported, else None."""
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
+            return None
+
+        for line in xrandr_output.split('\n'):
+            if display_name in line and ' connected' in line:
+                match = re.search(r" connected(?:\s+primary)?(?:\s+\d+x\d+\+\d+\+\d+)?\s+\(?(normal|left|right|inverted)\b", line)
+                rotation = match.group(1) if match else None
+                if rotation in self.SUPPORTED_ROTATIONS:
+                    return rotation
+                if rotation is not None:
+                    self.logger.warning(f"Unsupported rotation '{rotation}' for {display_name}")
+                return None
+
+        return None
+
+    def set_display_rotation(self, display_name, rotation):
+        """Set display rotation using xrandr."""
+        if rotation not in self.SUPPORTED_ROTATIONS:
+            self.logger.warning(f"Unsupported requested rotation '{rotation}'")
+            return False
+
+        try:
+            result = subprocess.run(
+                ['xrandr', '--output', display_name, '--rotate', rotation],
+                capture_output=True,
+                timeout=self.XRANDR_TIMEOUT
+            )
+            if result.returncode != 0:
+                self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
+                return False
+
+            self._xrandr_cache = None
+            return True
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"xrandr rotation command timed out after {self.XRANDR_TIMEOUT}s")
+            return False
+        except Exception as e:
+            self.logger.error(f"Failed to set display rotation: {e}")
+            return False
 
     def enable_display(self, display_name, scale=None):
         """Enable/turn on a display with optional scaling

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -166,6 +166,96 @@ class DisplayManager:
             self.logger.error(f"Failed to set display rotation: {e}")
             return False
 
+    def get_effective_display_scale(self, display_name):
+        """Return current app-convention scale for a display, or None when ambiguous."""
+        xrandr_output = self._get_xrandr_output()
+        if not xrandr_output:
+            return None
+
+        native_resolution = self.DISPLAY_RESOLUTIONS.get(display_name)
+        if not native_resolution:
+            return None
+
+        native_width, native_height = native_resolution
+
+        for line in xrandr_output.split('\n'):
+            if not re.search(rf"^{re.escape(display_name)}\\s+connected\\b", line):
+                continue
+
+            geometry_match = re.search(r"\b(\d+)x(\d+)\+\d+\+\d+\b", line)
+            if not geometry_match:
+                return None
+
+            current_width = int(geometry_match.group(1))
+            current_height = int(geometry_match.group(2))
+            if current_width <= 0 or current_height <= 0:
+                return None
+
+            width_scale = native_width / current_width
+            height_scale = native_height / current_height
+
+            # Conservative parsing: width/height must agree closely.
+            if abs(width_scale - height_scale) > 0.05:
+                return None
+
+            return (width_scale + height_scale) / 2.0
+
+        return None
+
+    def _apply_display_scale(self, display_name, scale=None):
+        """Apply one xrandr scale configuration to the provided display."""
+        native_resolution = self.DISPLAY_RESOLUTIONS.get(display_name)
+        cmd = ['xrandr', '--output', display_name]
+
+        if native_resolution:
+            native_width, native_height = native_resolution
+            cmd.extend(['--mode', f'{native_width}x{native_height}'])
+
+            if scale is None or scale == 1.0:
+                cmd.extend(['--panning', f'{native_width}x{native_height}'])
+                cmd.extend(['--scale', '1x1'])
+            else:
+                if scale <= 0:
+                    self.logger.error(f"Invalid scale {scale} for {display_name}")
+                    return False
+
+                # Our convention: scale=1.6 means "UI appears 1.6x larger" (lower effective DPI)
+                # xrandr convention: --scale 1.6 means "zoom out" (UI appears smaller)
+                # These are OPPOSITE, so we invert for xrandr.
+                scale_inv = 1.0 / scale
+                panning_width = int(native_width * scale_inv)
+                panning_height = int(native_height * scale_inv)
+
+                cmd.extend(['--panning', f'{panning_width}x{panning_height}'])
+                cmd.extend(['--scale', f'{scale_inv}x{scale_inv}'])
+                self.logger.info(
+                    f"Scaling: virtual desktop {panning_width}x{panning_height}, "
+                    f"xrandr scale {scale_inv:.3f}x{scale_inv:.3f} (our scale={scale}), "
+                    f"physical {native_width}x{native_height}"
+                )
+        else:
+            self.logger.warning(f"Unknown display {display_name}, using auto mode")
+            cmd.append('--auto')
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                timeout=self.XRANDR_TIMEOUT
+            )
+            if result.returncode != 0:
+                self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
+                return False
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"xrandr enable command timed out after {self.XRANDR_TIMEOUT}s")
+            return False
+        except Exception as e:
+            self.logger.error(f"Failed to run xrandr enable command: {e}")
+            return False
+
+        self._xrandr_cache = None
+        return True
+
     def enable_display(self, display_name, scale=None):
         """Enable/turn on a display with optional scaling
 
@@ -176,74 +266,34 @@ class DisplayManager:
                    This keeps touch input properly mapped.
         """
         try:
-            # Determine native resolution from display name mapping
-            if display_name in self.DISPLAY_RESOLUTIONS:
-                native_width, native_height = self.DISPLAY_RESOLUTIONS[display_name]
-            else:
-                self.logger.warning(f"Unknown display {display_name}, using auto mode")
-                native_width, native_height = None, None
+            should_reset_to_native = False
 
-            # Build xrandr command
-            cmd = ['xrandr', '--output', display_name]
+            if scale is not None and scale != 1.0:
+                current_scale = self.get_effective_display_scale(display_name)
+                if current_scale is not None and scale < current_scale:
+                    should_reset_to_native = True
+                    self.logger.info(
+                        f"Lowering scale on {display_name}: reset to 1.0 before applying {scale} "
+                        f"(current≈{current_scale:.3f})"
+                    )
 
-            if native_width and native_height:
-                # Always specify the exact mode for predictable behavior
-                cmd.extend(['--mode', f'{native_width}x{native_height}'])
-
-                if scale is not None and scale != 1.0:
-                    # Our convention: scale=1.6 means "UI appears 1.6x larger" (lower effective DPI)
-                    # xrandr convention: --scale 1.6 means "zoom out" (UI appears smaller)
-                    # These are OPPOSITE, so we invert for xrandr
-                    scale_inv = 1.0 / scale
-
-                    # Calculate panning size (virtual desktop size)
-                    # For our scale=1.6 (larger UI), we want SMALLER virtual desktop
-                    # Virtual size = native / our_scale = native * scale_inv
-                    panning_width = int(native_width * scale_inv)
-                    panning_height = int(native_height * scale_inv)
-
-                    # xrandr will scale UP this smaller virtual desktop to fill the physical panel
-                    # We pass scale_inv to xrandr because it's inverted from our convention
-                    cmd.extend(['--panning', f'{panning_width}x{panning_height}'])
-                    cmd.extend(['--scale', f'{scale_inv}x{scale_inv}'])
-                    self.logger.info(f"Scaling: virtual desktop {panning_width}x{panning_height}, "
-                                   f"xrandr scale {scale_inv:.3f}x{scale_inv:.3f} (our scale={scale}), "
-                                   f"physical {native_width}x{native_height}")
-                else:
-                    # No scaling - use native resolution with 1:1 scale
-                    cmd.extend(['--panning', f'{native_width}x{native_height}'])
-                    cmd.extend(['--scale', '1x1'])
-            else:
-                # Fallback to auto mode if we don't know the resolution
-                cmd.append('--auto')
-
-            # Run xrandr command (may produce spurious BadMatch errors on stderr)
-            try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    timeout=self.XRANDR_TIMEOUT
-                )
-                if result.returncode != 0:
-                    self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
-            except subprocess.TimeoutExpired:
-                self.logger.error(f"xrandr enable command timed out after {self.XRANDR_TIMEOUT}s")
+            if should_reset_to_native and not self._apply_display_scale(display_name, 1.0):
                 return False
-            
-            # Invalidate cache since display state changed
+
+            if not self._apply_display_scale(display_name, scale):
+                return False
+
+            # Preserve existing verification behavior after enable.
             self._xrandr_cache = None
-            
-            # Verify the display is actually enabled by checking its state
-            # Give X11 a moment to apply the change
             time.sleep(self.XRANDR_APPLY_DELAY)
 
             if self.is_display_active(display_name):
                 scale_info = f" with {scale}x scale" if scale and scale != 1.0 else ""
                 self.logger.info(f"Enabled display: {display_name}{scale_info}")
                 return True
-            else:
-                self.logger.error(f"Failed to enable display: {display_name} (display not active after command)")
-                return False
+
+            self.logger.error(f"Failed to enable display: {display_name} (display not active after command)")
+            return False
 
         except Exception as e:
             self.logger.error(f"Failed to enable display: {e}")

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -215,19 +215,28 @@ class DisplayManager:
             return None
 
         native_width, native_height = native_resolution
-        xrandr_scale_x = 1.0 / requested_scale
-        xrandr_scale_y = 1.0 / requested_scale
+        transform_scale_x = 1.0 / requested_scale
+        transform_scale_y = 1.0 / requested_scale
 
-        logical_width = max(1, math.ceil(native_width * xrandr_scale_x))
-        logical_height = max(1, math.ceil(native_height * xrandr_scale_y))
+        logical_width = max(1, math.ceil(native_width * transform_scale_x))
+        logical_height = max(1, math.ceil(native_height * transform_scale_y))
+        if transform_scale_x == 1.0 and transform_scale_y == 1.0:
+            transform_matrix = '1,0,0,0,1,0,0,0,1'
+        else:
+            transform_matrix = (
+                f'{transform_scale_x},0,0,'
+                f'0,{transform_scale_y},0,'
+                '0,0,1'
+            )
 
         return {
             'display_name': display_name,
             'native_width': native_width,
             'native_height': native_height,
             'requested_scale': requested_scale,
-            'xrandr_scale_x': xrandr_scale_x,
-            'xrandr_scale_y': xrandr_scale_y,
+            'transform_scale_x': transform_scale_x,
+            'transform_scale_y': transform_scale_y,
+            'transform_matrix': transform_matrix,
             'logical_width': logical_width,
             'logical_height': logical_height,
             'panning_width': logical_width,
@@ -264,17 +273,13 @@ class DisplayManager:
         return True
 
     def _apply_display_target_state(self, target_state):
-        """Apply xrandr using one coherent target state (mode, scale, panning, fb)."""
+        """Apply xrandr using one coherent target state (mode, transform, panning, fb)."""
         display_name = target_state['display_name']
-        scale_x = target_state['xrandr_scale_x']
-        scale_y = target_state['xrandr_scale_y']
-
-        scale_text = '1x1' if scale_x == 1.0 and scale_y == 1.0 else f'{scale_x}x{scale_y}'
 
         cmd = [
             'xrandr', '--output', display_name,
             '--mode', f"{target_state['native_width']}x{target_state['native_height']}",
-            '--scale', scale_text,
+            '--transform', target_state['transform_matrix'],
             '--panning', f"{target_state['panning_width']}x{target_state['panning_height']}",
             '--fb', f"{target_state['framebuffer_width']}x{target_state['framebuffer_height']}",
         ]
@@ -365,15 +370,6 @@ class DisplayManager:
         )
         return True
 
-    def _reset_display_to_native_baseline(self, display_name):
-        """Reset display to known-good native baseline before one retry."""
-        baseline = self._build_display_target_state(display_name, 1.0)
-        if not baseline:
-            return self._apply_display_scale(display_name, 1.0)
-
-        self.logger.info(f"Resetting {display_name} to native baseline before retry")
-        return self._apply_display_target_state(baseline)
-
     def _apply_display_scale(self, display_name, scale=None):
         """Apply one full xrandr target state to the provided display."""
         target_state = self._build_display_target_state(display_name, scale)
@@ -392,14 +388,10 @@ class DisplayManager:
             self.logger.warning(f"Unknown display {display_name}, using auto mode")
             return self._run_xrandr_apply_command(display_name, ['xrandr', '--output', display_name, '--auto'])
 
-        scale_x = target_state['xrandr_scale_x']
-        scale_y = target_state['xrandr_scale_y']
-        scale_text = '1x1' if scale_x == 1.0 and scale_y == 1.0 else f'{scale_x}x{scale_y}'
-
         cmd = [
             'xrandr', '--output', display_name,
             '--mode', f"{target_state['native_width']}x{target_state['native_height']}",
-            '--scale', scale_text,
+            '--transform', target_state['transform_matrix'],
         ]
         return self._run_xrandr_apply_command(display_name, cmd)
 

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -244,8 +244,10 @@ class DisplayManager:
                 timeout=self.XRANDR_TIMEOUT
             )
             if result.returncode != 0:
-                self.logger.warning(f"xrandr returned {result.returncode}: {result.stderr}")
-                return False
+                self.logger.warning(
+                    f"xrandr returned {result.returncode}: {result.stderr}; "
+                    "continuing and verifying display state"
+                )
         except subprocess.TimeoutExpired:
             self.logger.error(f"xrandr enable command timed out after {self.XRANDR_TIMEOUT}s")
             return False

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -202,40 +202,42 @@ class DisplayManager:
 
         return None
 
-    def _apply_display_scale(self, display_name, scale=None):
-        """Apply one xrandr scale configuration to the provided display."""
+    def _build_display_target_state(self, display_name, scale=None):
+        """Build one explicit target state for display apply/verify operations."""
         native_resolution = self.DISPLAY_RESOLUTIONS.get(display_name)
-        cmd = ['xrandr', '--output', display_name]
+        if not native_resolution:
+            return None
 
-        if native_resolution:
-            native_width, native_height = native_resolution
-            cmd.extend(['--mode', f'{native_width}x{native_height}'])
+        requested_scale = 1.0 if scale is None else float(scale)
+        if requested_scale <= 0:
+            self.logger.error(f"Invalid scale {scale} for {display_name}")
+            return None
 
-            if scale is None or scale == 1.0:
-                cmd.extend(['--panning', f'{native_width}x{native_height}'])
-                cmd.extend(['--scale', '1x1'])
-            else:
-                if scale <= 0:
-                    self.logger.error(f"Invalid scale {scale} for {display_name}")
-                    return False
+        native_width, native_height = native_resolution
+        xrandr_scale_x = 1.0 / requested_scale
+        xrandr_scale_y = 1.0 / requested_scale
 
-                # Our convention: scale=1.6 means "UI appears 1.6x larger" (lower effective DPI)
-                # xrandr convention: --scale 1.6 means "zoom out" (UI appears smaller)
-                # These are OPPOSITE, so we invert for xrandr.
-                scale_inv = 1.0 / scale
-                panning_width = int(native_width * scale_inv)
-                panning_height = int(native_height * scale_inv)
+        logical_width = max(1, int(native_width * xrandr_scale_x))
+        logical_height = max(1, int(native_height * xrandr_scale_y))
 
-                cmd.extend(['--panning', f'{panning_width}x{panning_height}'])
-                cmd.extend(['--scale', f'{scale_inv}x{scale_inv}'])
-                self.logger.info(
-                    f"Scaling: virtual desktop {panning_width}x{panning_height}, "
-                    f"xrandr scale {scale_inv:.3f}x{scale_inv:.3f} (our scale={scale}), "
-                    f"physical {native_width}x{native_height}"
-                )
-        else:
-            self.logger.warning(f"Unknown display {display_name}, using auto mode")
-            cmd.append('--auto')
+        return {
+            'display_name': display_name,
+            'native_width': native_width,
+            'native_height': native_height,
+            'requested_scale': requested_scale,
+            'xrandr_scale_x': xrandr_scale_x,
+            'xrandr_scale_y': xrandr_scale_y,
+            'logical_width': logical_width,
+            'logical_height': logical_height,
+            'panning_width': logical_width,
+            'panning_height': logical_height,
+            'framebuffer_width': logical_width,
+            'framebuffer_height': logical_height,
+        }
+
+    def _run_xrandr_apply_command(self, display_name, cmd):
+        cmd_text = " ".join(cmd)
+        self.logger.info(f"Running xrandr apply for {display_name}: {cmd_text}")
 
         try:
             result = subprocess.run(
@@ -245,9 +247,11 @@ class DisplayManager:
             )
             if result.returncode != 0:
                 self.logger.warning(
-                    f"xrandr returned {result.returncode}: {result.stderr}; "
+                    f"xrandr apply returned {result.returncode} for {display_name}: {result.stderr}; "
                     "continuing and verifying display state"
                 )
+            else:
+                self.logger.info(f"xrandr apply succeeded for {display_name}")
         except subprocess.TimeoutExpired:
             self.logger.error(f"xrandr enable command timed out after {self.XRANDR_TIMEOUT}s")
             return False
@@ -258,44 +262,191 @@ class DisplayManager:
         self._xrandr_cache = None
         return True
 
+    def _apply_display_target_state(self, target_state):
+        """Apply xrandr using one coherent target state (mode, scale, panning, fb)."""
+        display_name = target_state['display_name']
+        scale_x = target_state['xrandr_scale_x']
+        scale_y = target_state['xrandr_scale_y']
+
+        scale_text = '1x1' if scale_x == 1.0 and scale_y == 1.0 else f'{scale_x}x{scale_y}'
+
+        cmd = [
+            'xrandr', '--output', display_name,
+            '--mode', f"{target_state['native_width']}x{target_state['native_height']}",
+            '--scale', scale_text,
+            '--panning', f"{target_state['panning_width']}x{target_state['panning_height']}",
+            '--fb', f"{target_state['framebuffer_width']}x{target_state['framebuffer_height']}",
+        ]
+
+        return self._run_xrandr_apply_command(display_name, cmd)
+
+    def _extract_actual_randr_state(self, display_name, xrandr_output=None):
+        """Extract framebuffer and output geometry from xrandr output."""
+        output = xrandr_output if xrandr_output is not None else self._get_xrandr_output()
+        if not output:
+            return None
+
+        framebuffer_width = None
+        framebuffer_height = None
+        output_active = False
+        output_width = None
+        output_height = None
+
+        for line in output.split('\n'):
+            stripped = line.strip()
+            if stripped.startswith('Screen '):
+                match = re.search(r"current\s+(\d+)\s+x\s+(\d+)", stripped)
+                if match:
+                    framebuffer_width = int(match.group(1))
+                    framebuffer_height = int(match.group(2))
+                continue
+
+            if not re.search(rf"^{re.escape(display_name)}\s+connected\b", stripped):
+                continue
+
+            geo_match = re.search(r"\b(\d+)x(\d+)\+\d+\+\d+\b", stripped)
+            if geo_match:
+                output_active = True
+                output_width = int(geo_match.group(1))
+                output_height = int(geo_match.group(2))
+
+        return {
+            'framebuffer_width': framebuffer_width,
+            'framebuffer_height': framebuffer_height,
+            'output_active': output_active,
+            'output_width': output_width,
+            'output_height': output_height,
+        }
+
+    def _verify_display_target_state(self, display_name, target_state, xrandr_output=None):
+        """Verify post-apply RandR state matches the expected target state."""
+        actual = self._extract_actual_randr_state(display_name, xrandr_output=xrandr_output)
+        if not actual:
+            self.logger.warning(f"Could not read post-apply xrandr state for {display_name}")
+            return False
+
+        expected_width = target_state['logical_width']
+        expected_height = target_state['logical_height']
+
+        mismatches = {}
+
+        if not actual['output_active']:
+            mismatches['output_active'] = {'expected': True, 'actual': False}
+
+        fb_width = actual['framebuffer_width']
+        fb_height = actual['framebuffer_height']
+        if fb_width is None or fb_height is None:
+            mismatches['framebuffer'] = {'expected': 'present', 'actual': None}
+        else:
+            if fb_width < expected_width or fb_height < expected_height:
+                mismatches['framebuffer_too_small'] = {
+                    'expected_min': f"{expected_width}x{expected_height}",
+                    'actual': f"{fb_width}x{fb_height}",
+                }
+
+        if actual['output_width'] != expected_width or actual['output_height'] != expected_height:
+            mismatches['output_geometry'] = {
+                'expected': f"{expected_width}x{expected_height}",
+                'actual': (
+                    f"{actual['output_width']}x{actual['output_height']}"
+                    if actual['output_width'] is not None and actual['output_height'] is not None
+                    else None
+                ),
+            }
+
+        if mismatches:
+            self.logger.warning(f"Display state mismatch for {display_name}: {mismatches}")
+            return False
+
+        self.logger.info(
+            f"Verified display state for {display_name}: "
+            f"logical={expected_width}x{expected_height}, "
+            f"framebuffer={fb_width}x{fb_height}"
+        )
+        return True
+
+    def _reset_display_to_native_baseline(self, display_name):
+        """Reset display to known-good native baseline before one retry."""
+        baseline = self._build_display_target_state(display_name, 1.0)
+        if not baseline:
+            return self._apply_display_scale(display_name, 1.0)
+
+        self.logger.info(f"Resetting {display_name} to native baseline before retry")
+        return self._apply_display_target_state(baseline)
+
+    def _apply_display_scale(self, display_name, scale=None):
+        """Apply one full xrandr target state to the provided display."""
+        target_state = self._build_display_target_state(display_name, scale)
+        if target_state:
+            self.logger.info(f"Target state for {display_name}: {target_state}")
+            return self._apply_display_target_state(target_state)
+
+        self.logger.warning(f"Unknown display {display_name}, using auto mode")
+        cmd = ['xrandr', '--output', display_name, '--auto']
+        return self._run_xrandr_apply_command(display_name, cmd)
+
     def enable_display(self, display_name, scale=None):
-        """Enable/turn on a display with optional scaling
+        """Enable/turn on a display with optional scaling.
 
         Args:
             display_name: Name of the display (e.g., 'eDP-1', 'eDP-2')
             scale: Optional scale factor (e.g., 1.60 means UI appears 1.6x larger, lower DPI)
-                   Uses xrandr --scale with --panning to maintain full panel coverage.
-                   This keeps touch input properly mapped.
+                   Uses xrandr --scale with --panning and --fb for full-state transitions.
         """
         try:
-            should_reset_to_native = False
-
-            if scale is not None and scale != 1.0:
-                current_scale = self.get_effective_display_scale(display_name)
-                if current_scale is not None and scale < current_scale:
-                    should_reset_to_native = True
-                    self.logger.info(
-                        f"Lowering scale on {display_name}: reset to 1.0 before applying {scale} "
-                        f"(current≈{current_scale:.3f})"
-                    )
-
-            if should_reset_to_native and not self._apply_display_scale(display_name, 1.0):
-                return False
+            target_state = self._build_display_target_state(display_name, scale)
 
             if not self._apply_display_scale(display_name, scale):
                 return False
 
-            # Preserve existing verification behavior after enable.
             self._xrandr_cache = None
             time.sleep(self.XRANDR_APPLY_DELAY)
 
-            if self.is_display_active(display_name):
-                scale_info = f" with {scale}x scale" if scale and scale != 1.0 else ""
-                self.logger.info(f"Enabled display: {display_name}{scale_info}")
-                return True
+            verified = True
+            if target_state:
+                verified = self._verify_display_target_state(display_name, target_state)
+                if not verified:
+                    self.logger.warning(
+                        f"Post-apply verification failed for {display_name}; running one recovery attempt"
+                    )
+                    if not self._reset_display_to_native_baseline(display_name):
+                        return False
+                    if not self._apply_display_target_state(target_state):
+                        return False
 
-            self.logger.error(f"Failed to enable display: {display_name} (display not active after command)")
-            return False
+                    self._xrandr_cache = None
+                    time.sleep(self.XRANDR_APPLY_DELAY)
+                    verified = self._verify_display_target_state(display_name, target_state)
+            else:
+                verified = self.is_display_active(display_name)
+
+            if not verified:
+                self.logger.error(
+                    f"Failed to enable display: {display_name} "
+                    "(verification mismatch after one recovery attempt)"
+                )
+                return False
+
+            scale_info = f" with {scale}x scale" if scale and scale != 1.0 else ""
+            self.logger.info(f"Enabled display: {display_name}{scale_info}")
+
+            xrandr_output = self._get_xrandr_output()
+            if xrandr_output:
+                lines = xrandr_output.split('\n')
+                screen_line = next((line.strip() for line in lines if line.startswith('Screen ')), None)
+                active_line = next(
+                    (
+                        line.strip()
+                        for line in lines
+                        if re.search(rf"^{re.escape(display_name)}\\s+connected\\b", line)
+                    ),
+                    None,
+                )
+                if screen_line:
+                    self.logger.info(f"Post-enable xrandr screen: {screen_line}")
+                if active_line:
+                    self.logger.info(f"Post-enable xrandr output: {active_line}")
+            return True
 
         except Exception as e:
             self.logger.error(f"Failed to enable display: {e}")

--- a/DisplayManager.py
+++ b/DisplayManager.py
@@ -343,9 +343,9 @@ class DisplayManager:
         fb_height = actual['framebuffer_height']
         if fb_width is None or fb_height is None:
             mismatches['framebuffer'] = {'expected': 'present', 'actual': None}
-        elif fb_width != expected_width or fb_height != expected_height:
+        elif fb_width < expected_width or fb_height < expected_height:
             mismatches['framebuffer_size'] = {
-                'expected': f"{expected_width}x{expected_height}",
+                'expected_minimum': f"{expected_width}x{expected_height}",
                 'actual': f"{fb_width}x{fb_height}",
             }
 
@@ -369,6 +369,15 @@ class DisplayManager:
             f"framebuffer={fb_width}x{fb_height}"
         )
         return True
+
+    def _reset_display_to_native_baseline(self, display_name):
+        baseline_state = self._build_display_target_state(display_name, 1.0)
+        if not baseline_state:
+            self.logger.error(f"Cannot reset unknown display to native baseline: {display_name}")
+            return False
+
+        self.logger.info(f"Resetting {display_name} to native baseline before retry")
+        return self._apply_display_target_state(baseline_state)
 
     def _apply_display_scale(self, display_name, scale=None):
         """Apply one full xrandr target state to the provided display."""
@@ -453,8 +462,22 @@ class DisplayManager:
             time.sleep(self.XRANDR_APPLY_DELAY)
 
             if not self._verify_display_target_state(display_name, target_state):
-                self.logger.error(f"Failed to finalize single-display layout for {display_name}")
-                return False
+                if not self._reset_display_to_native_baseline(display_name):
+                    self.logger.error(f"Failed to finalize single-display layout for {display_name}")
+                    return False
+
+                self._xrandr_cache = None
+                time.sleep(self.XRANDR_APPLY_DELAY)
+
+                if not self._apply_display_target_state(target_state):
+                    return False
+
+                self._xrandr_cache = None
+                time.sleep(self.XRANDR_APPLY_DELAY)
+
+                if not self._verify_display_target_state(display_name, target_state):
+                    self.logger.error(f"Failed to finalize single-display layout for {display_name}")
+                    return False
 
             self.logger.info(
                 f"Finalized single-display layout for {display_name}: "

--- a/HelperClient.py
+++ b/HelperClient.py
@@ -12,46 +12,81 @@ import socket
 import struct
 import json
 import threading
+import time
 
 
 class HelperClient:
     """Client for communicating with privileged helper daemon via Unix socket"""
+    
+    # Connection retry settings
+    MAX_RETRIES = 3
+    RETRY_DELAYS = [0.5, 1.0, 2.0]  # Exponential backoff
     
     def __init__(self, logger):
         self.logger = logger
         self.socket = None
         self.connected = False
         self.lock = threading.Lock()
+        self.socket_path = None
+        self.last_error = None
     
     def connect(self, socket_path, timeout=10.0):
-        """Connect to helper daemon socket"""
-        try:
-            self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.socket.settimeout(timeout)
-            self.socket.connect(socket_path)
-            self.connected = True
-            self.logger.info(f"Connected to helper daemon at {socket_path}")
-            return True
-        except Exception as e:
-            self.logger.error(f"Failed to connect to helper: {e}")
-            self.connected = False
-            return False
+        """Connect to helper daemon socket with retry logic"""
+        self.socket_path = socket_path
+        
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                # Clean up any existing socket
+                self._close_socket()
+                
+                self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                self.socket.settimeout(timeout)
+                self.socket.connect(socket_path)
+                
+                # Verify connection with a quick test
+                self.socket.setblocking(False)
+                self.socket.setblocking(True)
+                
+                self.connected = True
+                self.last_error = None
+                self.logger.info(f"Connected to helper daemon at {socket_path}")
+                return True
+                
+            except socket.error as e:
+                self.last_error = str(e)
+                self.logger.warning(f"Connection attempt {attempt + 1}/{self.MAX_RETRIES} failed: {e}")
+                self._close_socket()
+                
+                # Wait before retry (except on last attempt)
+                if attempt < self.MAX_RETRIES - 1:
+                    time.sleep(self.RETRY_DELAYS[attempt])
+            
+            except Exception as e:
+                self.last_error = str(e)
+                self.logger.error(f"Unexpected error connecting to helper: {e}")
+                self._close_socket()
+                break
+        
+        self.connected = False
+        return False
     
     def disconnect(self):
         """Disconnect from helper daemon"""
-        if self.socket:
-            try:
-                # Send shutdown command
-                self.send_command('shutdown')
-            except:
-                pass
-            
-            try:
-                self.socket.close()
-            except:
-                pass
+        with self.lock:
+            if self.socket:
+                try:
+                    # Send shutdown command with timeout
+                    old_timeout = self.socket.gettimeout()
+                    self.socket.settimeout(2.0)  # Short timeout for shutdown
+                    self.send_command('shutdown')
+                    self.socket.settimeout(old_timeout)
+                except Exception as e:
+                    self.logger.debug(f"Error sending shutdown command: {e}")
+                
+                self._close_socket()
             
             self.connected = False
+            self.socket_path = None
             self.logger.info("Disconnected from helper daemon")
     
     def send_command(self, command, **params):
@@ -60,7 +95,7 @@ class HelperClient:
         Returns: response dict or None on error
         """
         if not self.connected or not self.socket:
-            raise RuntimeError("Not connected to helper daemon")
+            raise RuntimeError(f"Not connected to helper daemon. Last error: {self.last_error}")
         
         with self.lock:
             try:
@@ -73,42 +108,110 @@ class HelperClient:
                 # Serialize to JSON
                 message = json.dumps(command_data).encode('utf-8')
                 
+                # Validate message size (prevent overflow)
+                if len(message) > 1024 * 1024:  # 1MB limit
+                    raise ValueError(f"Message too large: {len(message)} bytes")
+                
                 # Send with length prefix
                 length_prefix = struct.pack('!I', len(message))
-                self.socket.sendall(length_prefix + message)
+                self._sendall_with_check(length_prefix + message)
                 
-                # Receive response length
+                # Receive response length with timeout handling
                 length_data = self._recv_exact(4)
                 if not length_data:
-                    raise RuntimeError("Connection closed by helper")
+                    raise RuntimeError("Connection closed by helper (no length header)")
                 
                 response_length = struct.unpack('!I', length_data)[0]
+                
+                # Validate response length
+                if response_length > 1024 * 1024:  # 1MB limit
+                    raise ValueError(f"Response too large: {response_length} bytes")
                 
                 # Receive response data
                 response_data = self._recv_exact(response_length)
                 if not response_data:
-                    raise RuntimeError("Connection closed by helper")
+                    raise RuntimeError("Connection closed by helper (incomplete response)")
                 
                 # Parse JSON response
-                response = json.loads(response_data.decode('utf-8'))
+                try:
+                    response = json.loads(response_data.decode('utf-8'))
+                except json.JSONDecodeError as e:
+                    raise RuntimeError(f"Invalid JSON response from helper: {e}")
                 
                 return response
                 
-            except Exception as e:
-                self.logger.error(f"Command error: {e}")
+            except socket.timeout as e:
+                self.logger.error(f"Command '{command}' timed out: {e}")
                 self.connected = False
+                self.last_error = f"Timeout: {e}"
+                raise RuntimeError(f"Command timed out: {e}")
+            
+            except socket.error as e:
+                self.logger.error(f"Socket error during '{command}': {e}")
+                self.connected = False
+                self.last_error = f"Socket error: {e}"
+                raise RuntimeError(f"Socket error: {e}")
+            
+            except Exception as e:
+                self.logger.error(f"Command '{command}' error: {e}")
+                self.connected = False
+                self.last_error = str(e)
                 raise
     
     def _recv_exact(self, num_bytes):
-        """Receive exactly num_bytes from socket"""
+        """Receive exactly num_bytes from socket with timeout handling"""
         data = b''
         while len(data) < num_bytes:
-            chunk = self.socket.recv(num_bytes - len(data))
-            if not chunk:
+            try:
+                chunk = self.socket.recv(num_bytes - len(data))
+                if not chunk:
+                    self.logger.warning(f"Connection closed while receiving data (got {len(data)}/{num_bytes} bytes)")
+                    return None
+                data += chunk
+            except socket.timeout:
+                self.logger.error(f"Timeout while receiving data (got {len(data)}/{num_bytes} bytes)")
+                raise
+            except socket.error as e:
+                self.logger.error(f"Socket error while receiving: {e}")
                 return None
-            data += chunk
         return data
+    
+    def _sendall_with_check(self, data):
+        """Send all data with error checking"""
+        try:
+            self.socket.sendall(data)
+        except socket.timeout:
+            self.logger.error("Timeout while sending data")
+            raise
+        except socket.error as e:
+            self.logger.error(f"Socket error while sending: {e}")
+            raise
+    
+    def _close_socket(self):
+        """Close socket safely"""
+        if self.socket:
+            try:
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except:
+                pass
+            try:
+                self.socket.close()
+            except:
+                pass
+            self.socket = None
     
     def is_connected(self):
         """Check if connected to helper"""
-        return self.connected
+        if not self.connected:
+            return False
+        
+        # Verify socket is still alive
+        if not self.socket:
+            self.connected = False
+            return False
+        
+        return True
+    
+    def get_last_error(self):
+        """Get the last connection error"""
+        return self.last_error

--- a/HelperClient.py
+++ b/HelperClient.py
@@ -5,204 +5,142 @@ WARNING: This software is provided "AS IS", without any warranty of any kind. It
 that result in data loss, corruption, hardware damage or other issues. Use at your own risk.
 It may temporarily or permanently render your hardware inoperable.
 It may corrupt or damage the Embedded Controller or eInk T-CON controller in your laptop.
-The author is not responsible for any damage, data loss or lost productivity caused by use of this software. 
+The author is not responsible for any damage, data loss or lost productivity caused by use of this software.
 By downloading and using this software you agree to these terms and acknowledge the risks involved.
 """
-import socket
-import struct
+
+import http.client
 import json
+import socket
 import threading
 import time
 
 
+class UnixSocketHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path, timeout=10.0):
+        super().__init__("localhost", timeout=timeout)
+        self.socket_path = socket_path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.settimeout(self.timeout)
+        self.sock.connect(self.socket_path)
+
+
 class HelperClient:
-    """Client for communicating with privileged helper daemon via Unix socket"""
-    
-    # Connection retry settings
+    """Client for communicating with privileged helper daemon via HTTP over Unix socket"""
+
     MAX_RETRIES = 3
-    RETRY_DELAYS = [0.5, 1.0, 2.0]  # Exponential backoff
-    
+    RETRY_DELAYS = [0.5, 1.0, 2.0]
+
+    ROUTES = {
+        "enable-eink": ("POST", "/v1/eink/enable", lambda params: {}),
+        "disable-eink": ("POST", "/v1/eink/disable", lambda params: {}),
+        "refresh-eink": ("POST", "/v1/eink/refresh", lambda params: {}),
+        "set-dynamic": ("POST", "/v1/eink/mode/dynamic", lambda params: {}),
+        "set-reading": ("POST", "/v1/eink/mode/reading", lambda params: {}),
+        "get-ec-status": ("GET", "/v1/ec/status", lambda params: None),
+        "get-frontlight-state": ("GET", "/v1/frontlight", lambda params: None),
+        "enable-frontlight": ("POST", "/v1/frontlight/enable", lambda params: {"brightness_level": params["brightness_level"]} if "brightness_level" in params else {}),
+        "disable-frontlight": ("POST", "/v1/frontlight/disable", lambda params: {}),
+        "set-brightness": ("POST", "/v1/frontlight/brightness", lambda params: {"level": params.get("level")}),
+    }
+
     def __init__(self, logger):
         self.logger = logger
-        self.socket = None
         self.connected = False
         self.lock = threading.Lock()
         self.socket_path = None
         self.last_error = None
-    
+        self.socket = None
+
     def connect(self, socket_path, timeout=10.0):
-        """Connect to helper daemon socket with retry logic"""
         self.socket_path = socket_path
-        
+
         for attempt in range(self.MAX_RETRIES):
             try:
-                # Clean up any existing socket
                 self._close_socket()
-                
-                self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                self.socket.settimeout(timeout)
-                self.socket.connect(socket_path)
-                
-                # Verify connection with a quick test
-                self.socket.setblocking(False)
-                self.socket.setblocking(True)
-                
+                probe = UnixSocketHTTPConnection(socket_path, timeout=timeout)
+                probe.connect()
+                self.socket = probe.sock
+                probe.close()
+                self.socket = None
+
                 self.connected = True
                 self.last_error = None
                 self.logger.info(f"Connected to helper daemon at {socket_path}")
                 return True
-                
-            except socket.error as e:
+            except Exception as e:
                 self.last_error = str(e)
                 self.logger.warning(f"Connection attempt {attempt + 1}/{self.MAX_RETRIES} failed: {e}")
                 self._close_socket()
-                
-                # Wait before retry (except on last attempt)
                 if attempt < self.MAX_RETRIES - 1:
                     time.sleep(self.RETRY_DELAYS[attempt])
-            
-            except Exception as e:
-                self.last_error = str(e)
-                self.logger.error(f"Unexpected error connecting to helper: {e}")
-                self._close_socket()
-                break
-        
+
         self.connected = False
         return False
-    
-    def disconnect(self):
-        """Disconnect from helper daemon client socket only (no server shutdown)."""
-        with self.lock:
-            if self.socket:
-                self._close_socket()
 
+    def disconnect(self):
+        with self.lock:
+            self._close_socket()
             self.connected = False
             self.socket_path = None
             self.logger.info("Disconnected from helper daemon")
-    
+
+    def _route_for(self, command, params):
+        if command not in self.ROUTES:
+            raise ValueError(f"Unknown command: {command}")
+        method, path, body_fn = self.ROUTES[command]
+        body_obj = body_fn(params)
+        return method, path, body_obj
+
     def send_command(self, command, **params):
-        """
-        Send command to helper and receive response
-        Returns: response dict or None on error
-        """
-        if not self.connected or not self.socket:
+        if not self.connected or not self.socket_path:
             raise RuntimeError(f"Not connected to helper daemon. Last error: {self.last_error}")
-        
+
         with self.lock:
             try:
-                # Prepare command
-                command_data = {
-                    'command': command,
-                    'params': params
-                }
-                
-                # Serialize to JSON
-                message = json.dumps(command_data).encode('utf-8')
-                
-                # Validate message size (prevent overflow)
-                if len(message) > 1024 * 1024:  # 1MB limit
-                    raise ValueError(f"Message too large: {len(message)} bytes")
-                
-                # Send with length prefix
-                length_prefix = struct.pack('!I', len(message))
-                self._sendall_with_check(length_prefix + message)
-                
-                # Receive response length with timeout handling
-                length_data = self._recv_exact(4)
-                if not length_data:
-                    raise RuntimeError("Connection closed by helper (no length header)")
-                
-                response_length = struct.unpack('!I', length_data)[0]
-                
-                # Validate response length
-                if response_length > 1024 * 1024:  # 1MB limit
-                    raise ValueError(f"Response too large: {response_length} bytes")
-                
-                # Receive response data
-                response_data = self._recv_exact(response_length)
-                if not response_data:
-                    raise RuntimeError("Connection closed by helper (incomplete response)")
-                
-                # Parse JSON response
-                try:
-                    response = json.loads(response_data.decode('utf-8'))
-                except json.JSONDecodeError as e:
-                    raise RuntimeError(f"Invalid JSON response from helper: {e}")
-                
-                return response
-                
-            except socket.timeout as e:
-                self.logger.error(f"Command '{command}' timed out: {e}")
-                self.connected = False
-                self.last_error = f"Timeout: {e}"
-                raise RuntimeError(f"Command timed out: {e}")
-            
-            except socket.error as e:
-                self.logger.error(f"Socket error during '{command}': {e}")
-                self.connected = False
-                self.last_error = f"Socket error: {e}"
-                raise RuntimeError(f"Socket error: {e}")
-            
-            except Exception as e:
-                self.logger.error(f"Command '{command}' error: {e}")
+                method, path, body_obj = self._route_for(command, params)
+                body = None
+                headers = {"Accept": "application/json"}
+                if body_obj is not None:
+                    body = json.dumps(body_obj).encode("utf-8")
+                    headers["Content-Type"] = "application/json"
+
+                conn = UnixSocketHTTPConnection(self.socket_path, timeout=10.0)
+                conn.request(method, path, body=body, headers=headers)
+                response = conn.getresponse()
+                raw = response.read()
+                conn.close()
+
+                payload = json.loads(raw.decode("utf-8")) if raw else {}
+                if response.status >= 400:
+                    self.last_error = payload.get("error", f"HTTP {response.status}")
+                    raise RuntimeError(self.last_error)
+
+                return payload
+
+            except (socket.timeout, socket.error, OSError) as e:
                 self.connected = False
                 self.last_error = str(e)
+                self.logger.error(f"Socket/HTTP error during '{command}': {e}")
+                raise RuntimeError(f"Socket error: {e}")
+            except Exception as e:
+                self.connected = False
+                self.last_error = str(e)
+                self.logger.error(f"Command '{command}' error: {e}")
                 raise
-    
-    def _recv_exact(self, num_bytes):
-        """Receive exactly num_bytes from socket with timeout handling"""
-        data = b''
-        while len(data) < num_bytes:
-            try:
-                chunk = self.socket.recv(num_bytes - len(data))
-                if not chunk:
-                    self.logger.warning(f"Connection closed while receiving data (got {len(data)}/{num_bytes} bytes)")
-                    return None
-                data += chunk
-            except socket.timeout:
-                self.logger.error(f"Timeout while receiving data (got {len(data)}/{num_bytes} bytes)")
-                raise
-            except socket.error as e:
-                self.logger.error(f"Socket error while receiving: {e}")
-                return None
-        return data
-    
-    def _sendall_with_check(self, data):
-        """Send all data with error checking"""
-        try:
-            self.socket.sendall(data)
-        except socket.timeout:
-            self.logger.error("Timeout while sending data")
-            raise
-        except socket.error as e:
-            self.logger.error(f"Socket error while sending: {e}")
-            raise
-    
+
     def _close_socket(self):
-        """Close socket safely"""
         if self.socket:
             try:
-                self.socket.shutdown(socket.SHUT_RDWR)
-            except:
-                pass
-            try:
                 self.socket.close()
-            except:
+            except Exception:
                 pass
             self.socket = None
-    
+
     def is_connected(self):
-        """Check if connected to helper"""
-        if not self.connected:
-            return False
-        
-        # Verify socket is still alive
-        if not self.socket:
-            self.connected = False
-            return False
-        
-        return True
-    
+        return self.connected and bool(self.socket_path)
+
     def get_last_error(self):
-        """Get the last connection error"""
         return self.last_error

--- a/HelperClient.py
+++ b/HelperClient.py
@@ -71,20 +71,11 @@ class HelperClient:
         return False
     
     def disconnect(self):
-        """Disconnect from helper daemon"""
+        """Disconnect from helper daemon client socket only (no server shutdown)."""
         with self.lock:
             if self.socket:
-                try:
-                    # Send shutdown command with timeout
-                    old_timeout = self.socket.gettimeout()
-                    self.socket.settimeout(2.0)  # Short timeout for shutdown
-                    self.send_command('shutdown')
-                    self.socket.settimeout(old_timeout)
-                except Exception as e:
-                    self.logger.debug(f"Error sending shutdown command: {e}")
-                
                 self._close_socket()
-            
+
             self.connected = False
             self.socket_path = None
             self.logger.info("Disconnected from helper daemon")

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -26,16 +26,18 @@ import struct
 import signal
 import threading
 import logging
+import atexit
 
 from WatchdogTimer import WatchdogTimer
 from ECController import ECController
 from EInkUSBController import EInkUSBController 
 
 # Configuration
-SOCKET_PATH = '/tmp/tinta4plus.sock'
+SOCKET_PATH = '/run/tinta4plus.sock'
 PID_FILE = '/tmp/tinta4plus.pid'
 WATCHDOG_TIMEOUT = 20.0  # seconds
 LOG_LEVEL = logging.DEBUG  # Changed to DEBUG for detailed EC port access logging
+SYSTEMD_FIRST_FD = 3
 
 
 class HelperDaemon:
@@ -58,6 +60,7 @@ class HelperDaemon:
         # Setup signal handlers
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
+        atexit.register(self.shutdown)
     
     def _signal_handler(self, signum, frame):
         """Handle termination signals"""
@@ -83,27 +86,21 @@ class HelperDaemon:
             self.logger.warning(f"Failed to remove PID file: {e}")
     
     def _create_socket(self):
-        """Create Unix domain socket"""
-        # Remove old socket if exists
-        if os.path.exists(self.socket_path):
-            os.remove(self.socket_path)
-        
-        self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.server_socket.bind(self.socket_path)
-        self.server_socket.listen(1)
-        
-        # Set permissions (readable/writable by all for simplicity)
-        os.chmod(self.socket_path, 0o666)
-        
-        self.logger.info(f"Listening on socket: {self.socket_path}")
+        """Use systemd socket activation only."""
+        listen_pid = os.environ.get('LISTEN_PID')
+        listen_fds = int(os.environ.get('LISTEN_FDS', '0'))
+
+        if not (listen_pid and int(listen_pid) == os.getpid() and listen_fds >= 1):
+            raise RuntimeError("Systemd socket activation not available (LISTEN_FDS/LISTEN_PID missing)")
+
+        self.server_socket = socket.socket(fileno=SYSTEMD_FIRST_FD)
+        self.logger.info(f"Using systemd-activated socket FD {SYSTEMD_FIRST_FD}")
     
     def _remove_socket(self):
-        """Remove socket file"""
+        """Close systemd-provided server socket."""
         try:
             if self.server_socket:
                 self.server_socket.close()
-            if os.path.exists(self.socket_path):
-                os.remove(self.socket_path)
             self.logger.info("Removed socket")
         except Exception as e:
             self.logger.warning(f"Failed to remove socket: {e}")
@@ -238,12 +235,6 @@ class HelperDaemon:
                 response['readback'] = f"0x{readback:02x}"
                 response['level'] = level
                 response['message'] = f'Brightness set to {level}' if success else f'Brightness set failed (readback mismatch)'
-            
-            elif cmd == 'shutdown':
-                response['success'] = True
-                response['message'] = 'Shutting down'
-                # Shutdown after sending response
-                threading.Timer(0.1, self.shutdown).start()
             
             else:
                 raise ValueError(f"Unknown command: {cmd}")
@@ -423,21 +414,30 @@ class HelperDaemon:
         sock.sendall(response_length + response_json)
     
     def shutdown(self):
-        """Shutdown the daemon"""
-        if not self.running:
-            return
-        
-        self.logger.info("Shutting down...")
+        """Shutdown the daemon (idempotent; always attempts cleanup)."""
+        was_running = self.running
         self.running = False
-        
+
+        if was_running:
+            self.logger.info("Shutting down...")
+        else:
+            self.logger.debug("Shutdown requested while not running; performing cleanup")
+
         # Cancel watchdog
-        self.watchdog.cancel()
-        
-        # Cleanup
-        self.cleanup_hardware()
+        try:
+            self.watchdog.cancel()
+        except Exception as e:
+            self.logger.debug(f"Watchdog cancel during shutdown failed: {e}")
+
+        # Cleanup resources even on early-startup failures
+        try:
+            self.cleanup_hardware()
+        except Exception as e:
+            self.logger.warning(f"Hardware cleanup failed: {e}")
+
         self._remove_socket()
         self._remove_pid_file()
-        
+
         self.logger.info("Shutdown complete")
 
 

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -28,14 +28,12 @@ import threading
 import logging
 import atexit
 
-from WatchdogTimer import WatchdogTimer
 from ECController import ECController
 from EInkUSBController import EInkUSBController 
 
 # Configuration
 SOCKET_PATH = '/run/tinta4plus.sock'
 PID_FILE = '/tmp/tinta4plus.pid'
-WATCHDOG_TIMEOUT = 20.0  # seconds
 LOG_LEVEL = logging.DEBUG  # Changed to DEBUG for detailed EC port access logging
 SYSTEMD_FIRST_FD = 3
 
@@ -53,9 +51,6 @@ class HelperDaemon:
         # Hardware controllers
         self.eink = None
         self.ec = None
-        
-        # Watchdog
-        self.watchdog = WatchdogTimer(WATCHDOG_TIMEOUT, self.shutdown, self.logger)
         
         # Setup signal handlers
         signal.signal(signal.SIGTERM, self._signal_handler)
@@ -144,17 +139,9 @@ class HelperDaemon:
             
             self.logger.debug(f"Handling command: {cmd}")
             
-            # Reset watchdog on any command
-            self.watchdog.reset()
-            
             response = {'success': False, 'error': None}
             
-            if cmd == 'keepalive':
-                # Simple keepalive/ping command
-                response['success'] = True
-                response['message'] = 'pong'
-            
-            elif cmd == 'enable-eink':
+            if cmd == 'enable-eink':
                 self.eink.enable_eink()
                 response['success'] = True
                 response['message'] = 'E-Ink display enabled'
@@ -355,22 +342,16 @@ class HelperDaemon:
             # Accept connections
             while self.running:
                 try:
-                    # Set timeout so we can check self.running periodically
-                    self.server_socket.settimeout(1.0)
-                    try:
-                        client_socket, _ = self.server_socket.accept()
-                        self.logger.info("Client connected")
-                        
-                        # Handle in a thread (though we expect only one client)
-                        client_thread = threading.Thread(
-                            target=self.handle_client,
-                            args=(client_socket,)
-                        )
-                        client_thread.daemon = True
-                        client_thread.start()
-                        
-                    except socket.timeout:
-                        continue
+                    client_socket, _ = self.server_socket.accept()
+                    self.logger.info("Client connected")
+                    
+                    # Handle in a thread (though we expect only one client)
+                    client_thread = threading.Thread(
+                        target=self.handle_client,
+                        args=(client_socket,)
+                    )
+                    client_thread.daemon = True
+                    client_thread.start()
                         
                 except Exception as e:
                     if self.running:
@@ -423,18 +404,11 @@ class HelperDaemon:
         else:
             self.logger.debug("Shutdown requested while not running; performing cleanup")
 
-        # Cancel watchdog
-        try:
-            self.watchdog.cancel()
-        except Exception as e:
-            self.logger.debug(f"Watchdog cancel during shutdown failed: {e}")
-
         # Cleanup resources even on early-startup failures
         try:
             self.cleanup_hardware()
         except Exception as e:
             self.logger.warning(f"Hardware cleanup failed: {e}")
-
         self._remove_socket()
         self._remove_pid_file()
 
@@ -474,7 +448,6 @@ def main():
     sys.excepthook = handle_exception
 
     logger.info("ThinkBook E-Ink Helper starting")
-    logger.info(f"Watchdog timeout: {WATCHDOG_TIMEOUT}s")
 
     daemon = HelperDaemon(logger)
     return daemon.run()
@@ -482,3 +455,5 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
+
+

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -1,459 +1,335 @@
 #!/usr/bin/env python3
 """
 Copyright (c) 2025 Jon Cox (joncox123). All rights reserved.
-
-WARNING: This software is provided "AS IS", without any warranty of any kind. It may contain bugs or other defects
-that result in data loss, corruption, hardware damage or other issues. Use at your own risk.
-It may temporarily or permanently render your hardware inoperable.
-It may corrupt or damage the Embedded Controller or eInk T-CON controller in your laptop.
-The author is not responsible for any damage, data loss or lost productivity caused by use of this software. 
-By downloading and using this software you agree to these terms and acknowledge the risks involved.
 """
 
-"""
-ThinkBook Plus Gen 4 IRU E-Ink Control Helper
-Privileged daemon for hardware control via Unix socket
-
-Requires: sudo/pkexec to run
-Dependencies: pyusb, portio (or python-periphery)
-"""
-
-import os
-import sys
 import json
-import socket
-import struct
-import signal
-import threading
 import logging
+import os
+import signal
+import socket
+import sys
+import time
 import atexit
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from ECController import ECController
-from EInkUSBController import EInkUSBController 
+from EInkUSBController import EInkUSBController
 
-# Configuration
 SOCKET_PATH = '/run/tinta4plus.sock'
 PID_FILE = '/tmp/tinta4plus.pid'
-LOG_LEVEL = logging.DEBUG  # Changed to DEBUG for detailed EC port access logging
+LOG_LEVEL = logging.DEBUG
 SYSTEMD_FIRST_FD = 3
 
 
+class HelperHTTPRequestHandler(BaseHTTPRequestHandler):
+    server_version = "Tinta4PlusHelper/1.0"
+
+    def _read_json_body(self):
+        length = int(self.headers.get('Content-Length', '0'))
+        raw = self.rfile.read(length) if length > 0 else b''
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw.decode('utf-8'))
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}")
+
+    def _send_json(self, status, payload):
+        data = json.dumps(payload).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _dispatch(self, method):
+        start = time.time()
+        status, payload = self.server.daemon.handle_http_request(method, self.path, self._read_raw_body_if_needed(method))
+        self._send_json(status, payload)
+        elapsed_ms = (time.time() - start) * 1000
+        self.server.daemon.logger.info(
+            f'HTTP unix-client "{method} {self.path}" {status} {elapsed_ms:.1f}ms'
+        )
+
+    def _read_raw_body_if_needed(self, method):
+        if method != 'POST':
+            return b''
+        length = int(self.headers.get('Content-Length', '0'))
+        return self.rfile.read(length) if length > 0 else b''
+
+    def do_POST(self):
+        self._dispatch('POST')
+
+    def do_GET(self):
+        self._dispatch('GET')
+
+    def log_message(self, fmt, *args):
+        return
+
+
+class ActivatedUnixHTTPServer(HTTPServer):
+    address_family = socket.AF_UNIX
+
+    def __init__(self, sock, daemon):
+        self.daemon = daemon
+        super().__init__(server_address=SOCKET_PATH, RequestHandlerClass=HelperHTTPRequestHandler, bind_and_activate=False)
+        self.socket = sock
+        self.server_address = SOCKET_PATH
+
+    def server_bind(self):
+        return
+
+    def server_activate(self):
+        return
+
+
 class HelperDaemon:
-    """Main helper daemon with socket server and hardware controllers"""
-    
     def __init__(self, logger):
         self.logger = logger
         self.running = False
         self.socket_path = SOCKET_PATH
         self.pid_file = PID_FILE
         self.server_socket = None
-        
-        # Hardware controllers
+        self.http_server = None
         self.eink = None
         self.ec = None
-        
-        # Setup signal handlers
+
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
         atexit.register(self.shutdown)
-    
+
     def _signal_handler(self, signum, frame):
-        """Handle termination signals"""
         self.logger.info(f"Received signal {signum}, shutting down")
         self.shutdown()
-    
+
     def _create_pid_file(self):
-        """Create PID file"""
         try:
             with open(self.pid_file, 'w') as f:
                 f.write(str(os.getpid()))
             self.logger.info(f"Created PID file: {self.pid_file}")
         except Exception as e:
             self.logger.error(f"Failed to create PID file: {e}")
-    
+
     def _remove_pid_file(self):
-        """Remove PID file"""
         try:
             if os.path.exists(self.pid_file):
                 os.remove(self.pid_file)
                 self.logger.info("Removed PID file")
         except Exception as e:
             self.logger.warning(f"Failed to remove PID file: {e}")
-    
+
     def _create_socket(self):
-        """Use systemd socket activation only."""
         listen_pid = os.environ.get('LISTEN_PID')
         listen_fds = int(os.environ.get('LISTEN_FDS', '0'))
-
         if not (listen_pid and int(listen_pid) == os.getpid() and listen_fds >= 1):
             raise RuntimeError("Systemd socket activation not available (LISTEN_FDS/LISTEN_PID missing)")
-
         self.server_socket = socket.socket(fileno=SYSTEMD_FIRST_FD)
         self.logger.info(f"Using systemd-activated socket FD {SYSTEMD_FIRST_FD}")
-    
+
     def _remove_socket(self):
-        """Close systemd-provided server socket."""
         try:
-            if self.server_socket:
+            if self.http_server:
+                self.http_server.server_close()
+                self.http_server = None
+            elif self.server_socket:
                 self.server_socket.close()
             self.logger.info("Removed socket")
         except Exception as e:
             self.logger.warning(f"Failed to remove socket: {e}")
-    
+
     def initialize_hardware(self):
-        """Initialize hardware controllers"""
         try:
-            # Initialize EC controller
             self.logger.info("Initializing EC controller")
             self.ec = ECController(self.logger)
-
-            # Check if EC access is available
             ec_status = self.ec.get_access_status()
             if not ec_status['available']:
                 self.logger.warning(f"EC access not available: {ec_status['error_message']}")
-                # Continue anyway - E-Ink will still work
 
-            # Initialize E-Ink USB controller
             self.logger.info("Initializing E-Ink USB controller")
             self.eink = EInkUSBController(self.logger)
             self.eink.connect()
-
             self.logger.info("Hardware initialization complete")
             return True
-
         except Exception as e:
             self.logger.error(f"Hardware initialization failed: {e}")
             return False
-    
+
     def cleanup_hardware(self):
-        """Cleanup hardware connections"""
         if self.eink:
             self.eink.disconnect()
         self.logger.info("Hardware cleanup complete")
-    
+
     def handle_command(self, command_data):
-        """Process a command and return response"""
         try:
             cmd = command_data.get('command')
             params = command_data.get('params', {})
-            
-            self.logger.debug(f"Handling command: {cmd}")
-            
             response = {'success': False, 'error': None}
-            
+
             if cmd == 'enable-eink':
-                self.eink.enable_eink()
-                response['success'] = True
-                response['message'] = 'E-Ink display enabled'
-
+                self.eink.enable_eink(); response['success'] = True; response['message'] = 'E-Ink display enabled'
             elif cmd == 'disable-eink':
-                self.eink.disable_eink()
-                response['success'] = True
-                response['message'] = 'E-Ink display disabled'
-            
+                self.eink.disable_eink(); response['success'] = True; response['message'] = 'E-Ink display disabled'
             elif cmd == 'refresh-eink':
-                self.eink.refresh_full()
-                response['success'] = True
-                response['message'] = 'E-Ink full refresh completed'
-
+                self.eink.refresh_full(); response['success'] = True; response['message'] = 'E-Ink full refresh completed'
             elif cmd == 'set-dynamic':
-                self.eink.set_dynamic_mode()
-                response['success'] = True
-                response['message'] = 'E-Ink set to Dynamic Mode (fast refresh)'
-
+                self.eink.set_dynamic_mode(); response['success'] = True; response['message'] = 'E-Ink set to Dynamic Mode (fast refresh)'
             elif cmd == 'set-reading':
-                self.eink.set_reading_mode()
-                response['success'] = True
-                response['message'] = 'E-Ink set to Reading Mode (high-quality refresh)'
-
+                self.eink.set_reading_mode(); response['success'] = True; response['message'] = 'E-Ink set to Reading Mode (high-quality refresh)'
             elif cmd == 'get-ec-status':
-                # Return EC access status
-                status = self.ec.get_access_status()
-                response['success'] = True
-                response['ec_status'] = status
-                response['message'] = 'EC status retrieved'
-
+                status = self.ec.get_access_status(); response['success'] = True; response['ec_status'] = status; response['message'] = 'EC status retrieved'
             elif cmd == 'get-frontlight-state':
-                # Read current frontlight state from EC
-                if not self.ec.access_available:
-                    raise RuntimeError(self.ec.error_message or "EC access not available")
-
-                enabled = self.ec.get_frontlight_state()
-                brightness = self.ec.read_brightness()
-
-                response['success'] = True
-                response['frontlight_enabled'] = enabled
-                response['brightness_level'] = brightness
-                response['message'] = 'Frontlight state retrieved'
-
+                if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
+                enabled = self.ec.get_frontlight_state(); brightness = self.ec.read_brightness()
+                response['success'] = True; response['frontlight_enabled'] = enabled; response['brightness_level'] = brightness; response['message'] = 'Frontlight state retrieved'
             elif cmd == 'enable-frontlight':
-                # Check EC access first
-                if not self.ec.access_available:
-                    raise RuntimeError(self.ec.error_message or "EC access not available")
-
-                # Get optional brightness level parameter
+                if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
                 brightness_level = params.get('brightness_level')
                 success, readback = self.ec.enable_frontlight(brightness_level=brightness_level)
-                response['success'] = success
-                response['readback'] = f"0x{readback:02x}"
-                response['message'] = 'Frontlight enabled' if success else 'Frontlight enable failed (readback mismatch)'
-
+                response['success'] = success; response['readback'] = f"0x{readback:02x}"; response['message'] = 'Frontlight enabled' if success else 'Frontlight enable failed (readback mismatch)'
             elif cmd == 'disable-frontlight':
-                # Check EC access first
-                if not self.ec.access_available:
-                    raise RuntimeError(self.ec.error_message or "EC access not available")
-
+                if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
                 success, readback = self.ec.disable_frontlight()
-                response['success'] = success
-                response['readback'] = f"0x{readback:02x}"
-                response['message'] = 'Frontlight disabled' if success else 'Frontlight disable failed (readback mismatch)'
-
+                response['success'] = success; response['readback'] = f"0x{readback:02x}"; response['message'] = 'Frontlight disabled' if success else 'Frontlight disable failed (readback mismatch)'
             elif cmd == 'set-brightness':
-                # Check EC access first
-                if not self.ec.access_available:
-                    raise RuntimeError(self.ec.error_message or "EC access not available")
-
+                if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
                 level = params.get('level')
-                if level is None:
-                    raise ValueError("Missing 'level' parameter")
-
+                if level is None: raise ValueError("Missing 'level' parameter")
                 success, readback = self.ec.set_brightness(int(level))
-                response['success'] = success
-                response['readback'] = f"0x{readback:02x}"
-                response['level'] = level
+                response['success'] = success; response['readback'] = f"0x{readback:02x}"; response['level'] = level
                 response['message'] = f'Brightness set to {level}' if success else f'Brightness set failed (readback mismatch)'
-            
             else:
                 raise ValueError(f"Unknown command: {cmd}")
-            
             return response
-            
         except Exception as e:
             self.logger.error(f"Command error: {e}")
-            return {
-                'success': False,
-                'error': str(e)
-            }
-    
-    def handle_client(self, client_socket):
-        """Handle a client connection with improved error handling"""
-        client_addr = "unix-client"
-        self.logger.info(f"Client connected: {client_addr}")
-        
+            return {'success': False, 'error': str(e)}
+
+    def handle_http_request(self, method, path, body_bytes):
+        start = time.time()
+        route_map = {
+            ('POST', '/v1/eink/enable'): ('enable-eink', {}),
+            ('POST', '/v1/eink/disable'): ('disable-eink', {}),
+            ('POST', '/v1/eink/refresh'): ('refresh-eink', {}),
+            ('POST', '/v1/eink/mode/dynamic'): ('set-dynamic', {}),
+            ('POST', '/v1/eink/mode/reading'): ('set-reading', {}),
+            ('GET', '/v1/ec/status'): ('get-ec-status', {}),
+            ('GET', '/v1/frontlight'): ('get-frontlight-state', {}),
+            ('POST', '/v1/frontlight/enable'): ('enable-frontlight', 'body'),
+            ('POST', '/v1/frontlight/disable'): ('disable-frontlight', {}),
+            ('POST', '/v1/frontlight/brightness'): ('set-brightness', 'body'),
+        }
+
+        all_paths = {p for _, p in route_map.keys()}
+        if path not in all_paths:
+            status, payload = 404, {'success': False, 'error': 'Not found'}
+            self._log_access(method, path, status, start)
+            return status, payload
+
+        key = (method, path)
+        if key not in route_map:
+            status, payload = 405, {'success': False, 'error': 'Method not allowed'}
+            self._log_access(method, path, status, start)
+            return status, payload
+
         try:
-            while self.running:
-                # Receive data (with 4-byte length prefix)
-                try:
-                    length_data = self._recv_exact(client_socket, 4)
-                    if not length_data:
-                        self.logger.info("Client disconnected (no data)")
-                        break
-                    
-                    msg_length = struct.unpack('!I', length_data)[0]
-                    
-                    # Validate message length
-                    if msg_length > 1024 * 1024:  # 1MB limit
-                        self.logger.error(f"Message too large: {msg_length} bytes, closing connection")
-                        break
-                    
-                    # Receive the message
-                    data = self._recv_exact(client_socket, msg_length)
-                    if not data or len(data) != msg_length:
-                        self.logger.warning(f"Incomplete message received (expected {msg_length}, got {len(data) if data else 0})")
-                        break
-                    
-                except socket.timeout:
-                    self.logger.debug("Client socket timeout, continuing...")
-                    continue
-                
-                except Exception as e:
-                    self.logger.error(f"Error receiving from client: {e}")
-                    break
-                
-                # Parse JSON command
-                try:
-                    command_data = json.loads(data.decode('utf-8'))
-                except json.JSONDecodeError as e:
-                    self.logger.error(f"Invalid JSON from client: {e}")
-                    error_response = {
-                        'success': False,
-                        'error': f"Invalid JSON: {e}"
-                    }
-                    self._send_response(client_socket, error_response)
-                    continue
-                
-                # Process command with timeout protection
-                try:
-                    response = self.handle_command(command_data)
-                except Exception as e:
-                    self.logger.error(f"Unhandled exception in command handler: {e}", exc_info=True)
-                    response = {
-                        'success': False,
-                        'error': f"Internal error: {e}"
-                    }
-                
-                # Send response
-                try:
-                    self._send_response(client_socket, response)
-                except Exception as e:
-                    self.logger.error(f"Error sending response to client: {e}")
-                    break
-                
+            parsed_body = {}
+            if body_bytes:
+                parsed_body = json.loads(body_bytes.decode('utf-8'))
+                if not isinstance(parsed_body, dict):
+                    raise ValueError('JSON body must be an object')
         except Exception as e:
-            self.logger.error(f"Client handler error: {e}", exc_info=True)
-        finally:
-            try:
-                client_socket.close()
-            except:
-                pass
-            self.logger.info("Client connection closed")
-    
+            status, payload = 400, {'success': False, 'error': f'Invalid JSON: {e}'}
+            self._log_access(method, path, status, start)
+            return status, payload
+
+        cmd, params_mode = route_map[key]
+        params = parsed_body if params_mode == 'body' else {}
+        payload = self.handle_command({'command': cmd, 'params': params})
+        status = 200
+        self._log_access(method, path, status, start)
+        return status, payload
+
+    def _log_access(self, method, path, status, start):
+        elapsed_ms = (time.time() - start) * 1000
+        self.logger.info(f'HTTP unix-client "{method} {path}" {status} {elapsed_ms:.1f}ms')
+
     def run(self):
-        """Main server loop"""
         try:
-            # Check if already running
             if os.path.exists(self.pid_file):
                 self.logger.warning(f"PID file exists: {self.pid_file}")
                 try:
                     with open(self.pid_file, 'r') as f:
                         old_pid = int(f.read().strip())
-                    # Check if process is still running
                     os.kill(old_pid, 0)
                     self.logger.error(f"Helper already running (PID {old_pid})")
                     return 1
                 except (OSError, ValueError):
                     self.logger.info("Stale PID file, removing")
                     os.remove(self.pid_file)
-            
-            # Create PID file
+
             self._create_pid_file()
-            
-            # Initialize hardware
             if not self.initialize_hardware():
                 self.logger.error("Failed to initialize hardware")
                 return 1
-            
-            # Create socket
+
             self._create_socket()
-            
             self.running = True
-            self.logger.info("Helper daemon started, waiting for connections")
-            
-            # Accept connections
-            while self.running:
-                try:
-                    client_socket, _ = self.server_socket.accept()
-                    self.logger.info("Client connected")
-                    
-                    # Handle in a thread (though we expect only one client)
-                    client_thread = threading.Thread(
-                        target=self.handle_client,
-                        args=(client_socket,)
-                    )
-                    client_thread.daemon = True
-                    client_thread.start()
-                        
-                except Exception as e:
-                    if self.running:
-                        self.logger.error(f"Accept error: {e}")
-                        break
-            
+            self.http_server = ActivatedUnixHTTPServer(self.server_socket, self)
+            self.logger.info("Helper daemon started (HTTP), waiting for connections")
+            self.http_server.serve_forever(poll_interval=0.5)
             return 0
-            
         except Exception as e:
             self.logger.error(f"Fatal error: {e}")
             return 1
-        
         finally:
             self.shutdown()
-    
-    def _recv_exact(self, sock, num_bytes):
-        """Receive exactly num_bytes from socket"""
-        data = b''
-        while len(data) < num_bytes:
-            chunk = sock.recv(num_bytes - len(data))
-            if not chunk:
-                return None
-            data += chunk
-        return data
-    
-    def _send_response(self, sock, response):
-        """Send JSON response with length prefix"""
-        response_json = json.dumps(response).encode('utf-8')
-        
-        # Validate response size
-        if len(response_json) > 1024 * 1024:
-            self.logger.error(f"Response too large: {len(response_json)} bytes")
-            # Send error response instead
-            error_response = json.dumps({
-                'success': False,
-                'error': 'Response too large'
-            }).encode('utf-8')
-            response_json = error_response
-        
-        response_length = struct.pack('!I', len(response_json))
-        sock.sendall(response_length + response_json)
-    
+
     def shutdown(self):
-        """Shutdown the daemon (idempotent; always attempts cleanup)."""
         was_running = self.running
         self.running = False
-
         if was_running:
             self.logger.info("Shutting down...")
-        else:
-            self.logger.debug("Shutdown requested while not running; performing cleanup")
 
-        # Cleanup resources even on early-startup failures
+        try:
+            if self.http_server:
+                self.http_server.shutdown()
+        except Exception:
+            pass
+
         try:
             self.cleanup_hardware()
         except Exception as e:
             self.logger.warning(f"Hardware cleanup failed: {e}")
+
         self._remove_socket()
         self._remove_pid_file()
-
         self.logger.info("Shutdown complete")
 
 
 def main():
-    """Entry point"""
-    # Check if running as root
     if os.geteuid() != 0:
         print("ERROR: This helper must be run as root (use pkexec or sudo)", file=sys.stderr)
         return 1
 
-    # Setup logging
     log_handlers = [
-        logging.StreamHandler(sys.stderr),  # Console output
-        logging.FileHandler('/tmp/TintaHelper.log', mode='w')  # File output (overwrite mode)
+        logging.StreamHandler(sys.stderr),
+        logging.FileHandler('/tmp/TintaHelper.log', mode='w')
     ]
-
-    logging.basicConfig(
-        level=LOG_LEVEL,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=log_handlers
-    )
+    logging.basicConfig(level=LOG_LEVEL, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', handlers=log_handlers)
     logger = logging.getLogger('tinta4plus-helper')
 
-    # Setup exception hook to log uncaught exceptions
     def handle_exception(exc_type, exc_value, exc_traceback):
-        """Log uncaught exceptions"""
         if issubclass(exc_type, KeyboardInterrupt):
-            # Allow keyboard interrupt to exit normally
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
             return
-
         logger.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
     sys.excepthook = handle_exception
-
     logger.info("ThinkBook E-Ink Helper starting")
-
     daemon = HelperDaemon(logger)
     return daemon.run()
 
 
 if __name__ == '__main__':
     sys.exit(main())
-
-

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -160,6 +160,11 @@ class HelperDaemon:
             self.eink.disconnect()
         self.logger.info("Hardware cleanup complete")
 
+    def _set_frontlight_response(self, response, success, readback, success_msg, failure_msg):
+        response['success'] = success
+        response['readback'] = f"0x{readback:02x}"
+        response['message'] = success_msg if success else failure_msg
+
     def handle_command(self, command_data):
         try:
             cmd = command_data.get('command')
@@ -186,18 +191,53 @@ class HelperDaemon:
                 if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
                 brightness_level = params.get('brightness_level')
                 success, readback = self.ec.enable_frontlight(brightness_level=brightness_level)
-                response['success'] = success; response['readback'] = f"0x{readback:02x}"; response['message'] = 'Frontlight enabled' if success else 'Frontlight enable failed (readback mismatch)'
+                self._set_frontlight_response(
+                    response,
+                    success,
+                    readback,
+                    'Frontlight enabled',
+                    'Frontlight enable failed (readback mismatch)',
+                )
             elif cmd == 'disable-frontlight':
                 if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
                 success, readback = self.ec.disable_frontlight()
-                response['success'] = success; response['readback'] = f"0x{readback:02x}"; response['message'] = 'Frontlight disabled' if success else 'Frontlight disable failed (readback mismatch)'
+                self._set_frontlight_response(
+                    response,
+                    success,
+                    readback,
+                    'Frontlight disabled',
+                    'Frontlight disable failed (readback mismatch)',
+                )
             elif cmd == 'set-brightness':
                 if not self.ec.access_available: raise RuntimeError(self.ec.error_message or "EC access not available")
                 level = params.get('level')
                 if level is None: raise ValueError("Missing 'level' parameter")
-                success, readback = self.ec.set_brightness(int(level))
-                response['success'] = success; response['readback'] = f"0x{readback:02x}"; response['level'] = level
-                response['message'] = f'Brightness set to {level}' if success else f'Brightness set failed (readback mismatch)'
+
+                level = int(level)
+                response['level'] = level
+                if level == 0:
+                    success, readback = self.ec.disable_frontlight()
+                    self._set_frontlight_response(
+                        response,
+                        success,
+                        readback,
+                        'Frontlight disabled via brightness level 0',
+                        'Frontlight disable failed (readback mismatch)',
+                    )
+                else:
+                    enable_success, _ = self.ec.enable_frontlight()
+                    if not enable_success:
+                        response['success'] = False
+                        response['error'] = 'Failed to enable frontlight before setting brightness'
+                    else:
+                        success, readback = self.ec.set_brightness(level)
+                        self._set_frontlight_response(
+                            response,
+                            success,
+                            readback,
+                            f'Brightness set to {level}',
+                            f'Brightness set failed (readback mismatch)',
+                        )
             else:
                 raise ValueError(f"Unknown command: {cmd}")
             return response

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -354,9 +354,8 @@ def main():
 
     log_handlers = [
         logging.StreamHandler(sys.stderr),
-        logging.FileHandler('/tmp/TintaHelper.log', mode='a')
     ]
-    logging.basicConfig(level=LOG_LEVEL, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', handlers=log_handlers)
+    logging.basicConfig(level=LOG_LEVEL, format='%(name)s - %(levelname)s - %(message)s', handlers=log_handlers)
     logger = logging.getLogger('tinta4plus-helper')
 
     def handle_exception(exc_type, exc_value, exc_traceback):

--- a/HelperDaemon.py
+++ b/HelperDaemon.py
@@ -354,7 +354,7 @@ def main():
 
     log_handlers = [
         logging.StreamHandler(sys.stderr),
-        logging.FileHandler('/tmp/TintaHelper.log', mode='w')
+        logging.FileHandler('/tmp/TintaHelper.log', mode='a')
     ]
     logging.basicConfig(level=LOG_LEVEL, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', handlers=log_handlers)
     logger = logging.getLogger('tinta4plus-helper')

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ At the present time, Tinta4Plus only works on exactly the following system confi
 
 To run the app, simply cd into the extracted directory and execute: ./Tinta4Plus.py
 
+## Systemd socket-activated helper (recommended)
+
+Tinta4Plus now supports a systemd socket-activated privileged helper so normal app launches do not require runtime `pkexec` prompts.
+
+The app performs install/update flow directly when needed.
+
 ## Missing Features and Known Bugs
 - Display scaling is not being handeled correctly during switch, which also causes the eInk touch mapping to be off.
 - Haven't figured out how to change the eInk contrast yet.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ At the present time, Tinta4Plus only works on exactly the following system confi
 
 To run the app, simply cd into the extracted directory and execute: ./Tinta4Plus.py
 
+For a minimal CLI toggle (no options), run: `./toggle-eink.py`
+
+The CLI now uses the same mode-switch path as the GUI, including privacy image handling and optional XFCE theme autoswitch behavior from `~/.config/Tinta4Plus/settings`.
+
 ## Systemd socket-activated helper (recommended)
 
 Tinta4Plus now supports a systemd socket-activated privileged helper so normal app launches do not require runtime `pkexec` prompts.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ Tinta4Plus now supports a systemd socket-activated privileged helper so normal a
 
 The app performs install/update flow directly when needed.
 
+### Helper HTTP API (Unix socket)
+
+Transport: HTTP over Unix domain socket at `/run/tinta4plus.sock`.
+
+Versioned endpoints:
+- `POST /v1/eink/enable`
+- `POST /v1/eink/disable`
+- `POST /v1/eink/refresh`
+- `POST /v1/eink/mode/dynamic`
+- `POST /v1/eink/mode/reading`
+- `GET  /v1/ec/status`
+- `GET  /v1/frontlight`
+- `POST /v1/frontlight/enable` (optional JSON: `{"brightness_level": <int>}`)
+- `POST /v1/frontlight/disable`
+- `POST /v1/frontlight/brightness` (JSON: `{"level": <int>}`)
+
+Response format remains JSON with existing keys like `success`, `error`, and command-specific fields.
+
+Server access log format (console/log file):
+- `HTTP unix-client "<METHOD> <PATH>" <STATUS> <DURATION_MS>ms`
+- Example: `HTTP unix-client "POST /v1/frontlight/brightness" 200 3.8ms`
+
 ## Missing Features and Known Bugs
 - Display scaling is not being handeled correctly during switch, which also causes the eInk touch mapping to be off.
 - Haven't figured out how to change the eInk contrast yet.

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -1050,16 +1050,8 @@ class EInkControlGUI:
         """Handle window close"""
         self.logger.info("Application closing")
 
-        # If eInk is currently active, automatically switch back to OLED
-        # to display privacy image and prevent exposure of personal information
-        if self.eink_enabled_var.get():
-            self.log_message("eInk display is active - switching back to OLED before exit...")
-            self.logger.info("eInk active at exit - automatically switching to OLED")
-
-            # Trigger the toggle to switch back to OLED (this will display privacy image)
-            self.on_eink_toggled()
-
-            self.log_message("✓ Automatic switch to OLED completed")
+        # Do not change hardware display mode on exit.
+        # Persisted user preferences are already saved when changed.
 
         # Stop refresh timer
         self._stop_refresh_timer()

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -37,8 +37,8 @@ from HelperClient import HelperClient
 from DisplayManager import DisplayManager
 from mode_switch import (
     _apply_input_mode,
-    ensure_touch_available,
     get_display_state,
+    reconcile_touch,
     save_orientation_preference,
     switch_to_eink,
     switch_to_oled,
@@ -178,6 +178,7 @@ class FloatingRefreshButton:
 class EInkControlGUI:
     # Version
     VERSION = "0.1.0 alpha"
+    ACTIVATION_RECONCILE_DEBOUNCE_SECONDS = 0.5
 
     # Configuration
     SOCKET_PATH = '/run/tinta4plus.sock'
@@ -246,6 +247,9 @@ class EInkControlGUI:
 
         # Build UI
         self.build_ui()
+        self._last_activation_reconcile_at = None
+
+        EInkControlGUI._bind_activation_reconcile(self, self.root)
 
         # Apply loaded settings to UI controls after they're created
         self.scale_var.set(self.display_scale)
@@ -857,12 +861,36 @@ class EInkControlGUI:
             self.show_error_dialog(f"Command '{command}' error:\n\n{e}")
             return None
     
+    def _bind_activation_reconcile(self, window):
+        if window is None:
+            return
+
+        handler = getattr(self, "_on_window_activated", None)
+        if handler is None:
+            handler = lambda event: EInkControlGUI._on_window_activated(self, event)
+
+        try:
+            window.bind("<FocusIn>", handler, add="+")
+        except Exception as e:
+            self.logger.debug(f"Failed to bind activation reconcile handler: {e}")
+
+    def _on_window_activated(self, _event=None):
+        now = time.monotonic()
+        last_run = getattr(self, "_last_activation_reconcile_at", None)
+        debounce_window = getattr(self, "ACTIVATION_RECONCILE_DEBOUNCE_SECONDS", 0.5)
+        if last_run is not None and now - last_run < debounce_window:
+            return
+
+        self._last_activation_reconcile_at = now
+        reconcile_touch(self.logger, self.display_mgr, reason="window_activation")
+
     def _ensure_floating_refresh_button(self):
         if self.floating_refresh_button:
             return
 
         self.log_message("Creating floating refresh button...")
         self.floating_refresh_button = FloatingRefreshButton(self.root, self.on_refresh_full, self.logger)
+        EInkControlGUI._bind_activation_reconcile(self, self.floating_refresh_button.window)
 
     def _destroy_floating_refresh_button(self):
         if not self.floating_refresh_button:
@@ -930,7 +958,12 @@ class EInkControlGUI:
         if remap_target is None or not _apply_input_mode(self.logger, remap_target):
             self.log_message("⚠ Rotation succeeded but input remap failed", level='warning')
         else:
-            ensure_touch_available(self.logger, remap_target)
+            reconcile_touch(
+                self.logger,
+                self.display_mgr,
+                target=remap_target,
+                reason="orientation_toggled",
+            )
 
         save_orientation_preference(self.logger, confirmed_rotation)
         self.update_status(f"Orientation set to {label}")
@@ -1075,7 +1108,12 @@ class EInkControlGUI:
                             self._live_sync_state["last_eink_orientation"] = confirmed_rotation
 
                         if _apply_input_mode(self.logger, "eink"):
-                            ensure_touch_available(self.logger, "eink")
+                            reconcile_touch(
+                                self.logger,
+                                self.display_mgr,
+                                target="eink",
+                                reason="lid_state_reconcile",
+                            )
                         else:
                             self.log_message("⚠ Lid-driven rotation succeeded but input remap failed", level='warning')
 

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -44,6 +44,8 @@ from mode_switch import (
     switch_to_oled,
 )
 
+LOG_FILE = '/tmp/TintaHelper.log'
+
 class FloatingRefreshButton:
     """Floating refresh button window that stays on top"""
 
@@ -1572,22 +1574,26 @@ def show_disclaimer_dialog(parent=None):
         return False
 
 
+def setup_logger():
+    logger = logging.getLogger('tinta4plus-gui')
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+
+    file_handler = logging.FileHandler(LOG_FILE, mode='a')
+    file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+
+    logger.handlers = [stream_handler, file_handler]
+    return logger
+
+
 def main():
     """Entry point"""
     HELPER_SCRIPT = '/usr/local/lib/tinta4plus/HelperDaemon.py'
 
-    # Setup logging
-    log_handlers = [
-        logging.StreamHandler(),  # Console output
-        logging.FileHandler('/tmp/tinta4plus.log', mode='w')  # File output (overwrite mode)
-    ]
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=log_handlers
-    )
-    logger = logging.getLogger('tinta4plus-gui')
+    logger = setup_logger()
 
     # Setup exception hook to log uncaught exceptions
     def handle_exception(exc_type, exc_value, exc_traceback):

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -28,6 +28,7 @@ import logging
 import webbrowser
 import json
 import grp
+import shutil
 from multiprocessing import Process, Pipe
 from datetime import datetime
 
@@ -599,8 +600,47 @@ class EInkControlGUI:
     def _get_installer_path(self):
         return os.path.join(self._get_script_dir(), 'scripts', 'install-systemd-helper-root.sh')
 
+    def _get_user_unit_source_path(self):
+        return os.path.join(
+            self._get_script_dir(),
+            'contrib',
+            'systemd',
+            'user',
+            'tinta4plus-disable-eink-output.service',
+        )
+
+    def _get_user_unit_dest_path(self):
+        return os.path.expanduser('~/.config/systemd/user/tinta4plus-disable-eink-output.service')
+
+    def _needs_user_unit_install_or_upgrade(self):
+        source = self._get_user_unit_source_path()
+        dest = self._get_user_unit_dest_path()
+        unit_name = os.path.basename(dest)
+
+        if not os.path.exists(source):
+            return True, f"User unit source not found: {source}"
+        if not os.path.exists(dest):
+            return True, None
+
+        try:
+            with open(source, 'rb') as source_file, open(dest, 'rb') as dest_file:
+                if source_file.read() != dest_file.read():
+                    return True, None
+        except Exception as e:
+            return True, f"Could not compare user unit: {e}"
+
+        result = subprocess.run(
+            ['systemctl', '--user', 'is-enabled', unit_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return True, None
+
+        return False, None
+
     def _needs_helper_install_or_upgrade(self):
-        """Use installer --check mode to detect drift or missing setup."""
+        """Use installer --check mode plus user-unit checks to detect drift or missing setup."""
         installer = self._get_installer_path()
         if not os.path.exists(installer):
             return True, f"Installer not found: {installer}"
@@ -609,14 +649,14 @@ class EInkControlGUI:
         command = [installer, '--check', '--source-dir', self._get_script_dir(), '--user', user_name]
         result = subprocess.run(command, capture_output=True, text=True)
 
-        if result.returncode == 0:
-            return False, None
-
         if result.returncode == 1:
             return True, None
 
-        details = (result.stderr or result.stdout or '').strip()
-        return True, details or f"Check failed with exit code {result.returncode}"
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or '').strip()
+            return True, details or f"Check failed with exit code {result.returncode}"
+
+        return self._needs_user_unit_install_or_upgrade()
 
     def _is_current_process_in_helper_group(self):
         """Return True when this running process has tinta4plus group in its group list."""
@@ -639,6 +679,29 @@ class EInkControlGUI:
             details = (result.stderr or result.stdout or '').strip()
             return False, details or f"Installer failed with exit code {result.returncode}"
 
+        return self._install_user_unit()
+
+    def _install_user_unit(self):
+        source = self._get_user_unit_source_path()
+        dest = self._get_user_unit_dest_path()
+        unit_name = os.path.basename(dest)
+
+        try:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            shutil.copyfile(source, dest)
+        except Exception as e:
+            return False, f"Failed to install user unit: {e}"
+
+        commands = [
+            ['systemctl', '--user', 'daemon-reload'],
+            ['systemctl', '--user', 'enable', '--now', unit_name],
+        ]
+        for command in commands:
+            result = subprocess.run(command, capture_output=True, text=True)
+            if result.returncode != 0:
+                details = (result.stderr or result.stdout or '').strip()
+                return False, details or f"Command failed: {' '.join(command)}"
+
         return True, None
 
     def _prompt_install_or_upgrade(self):
@@ -651,8 +714,10 @@ class EInkControlGUI:
 
         if needs_install:
             prompt = (
-                "Tinta4Plus needs to install or update the system helper service.\n\n"
-                "This is a one-time privileged action using pkexec.\n"
+                "Tinta4Plus needs to install or update the system helper service "
+                "and startup display unit.\n\n"
+                "This uses pkexec for the privileged helper, then enables the user "
+                "display unit with systemctl --user enable --now.\n"
                 "Install now?"
             )
         else:
@@ -666,8 +731,8 @@ class EInkControlGUI:
         if not install_now:
             return False
 
-        self.update_status("Installing/updating helper service (password required)...")
-        self.log_message("Installing/updating helper service via pkexec...")
+        self.update_status("Installing/updating helper service and startup display unit (password required)...")
+        self.log_message("Installing/updating helper service via pkexec and user display unit...")
         ok, error = self._run_helper_installer()
         if not ok:
             self.log_message(f"ERROR: Helper install failed - {error}", level='error')
@@ -683,7 +748,7 @@ class EInkControlGUI:
             self.log_message("Group membership update requires re-login before reconnect", level='warning')
             return False
 
-        self.log_message("✓ Helper service installed/updated")
+        self.log_message("✓ Helper service and startup display unit installed/updated")
         return True
 
     def initialize_helper(self):

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -32,7 +32,7 @@ from datetime import datetime
 
 from HelperClient import HelperClient
 from DisplayManager import DisplayManager
-from mode_switch import switch_to_eink, switch_to_oled
+from mode_switch import get_display_state, switch_to_eink, switch_to_oled
 
 class FloatingRefreshButton:
     """Floating refresh button window that stays on top"""
@@ -813,6 +813,52 @@ class EInkControlGUI:
             self.show_error_dialog(f"Command '{command}' error:\n\n{e}")
             return None
     
+    def _ensure_floating_refresh_button(self):
+        if self.floating_refresh_button:
+            return
+
+        self.log_message("Creating floating refresh button...")
+        self.floating_refresh_button = FloatingRefreshButton(self.root, self.on_refresh_full, self.logger)
+
+    def _destroy_floating_refresh_button(self):
+        if not self.floating_refresh_button:
+            return
+
+        self.log_message("Destroying floating refresh button...")
+        self.floating_refresh_button.destroy()
+        self.floating_refresh_button = None
+
+    def sync_ui_from_display_state(self):
+        state = get_display_state(self.display_mgr)
+        mode = state["mode"]
+
+        if mode == "eink":
+            self.eink_enabled_var.set(True)
+            self.eink_toggle_btn.config(text="eInk Enabled", bg="green", fg="white")
+            self.btn_refresh.config(state='normal')
+            self.btn_set_dynamic.config(state='normal')
+            self.btn_set_reading.config(state='normal')
+            self._start_refresh_timer()
+            self._ensure_floating_refresh_button()
+            self.update_status("E-Ink display enabled")
+            return state
+
+        self.eink_enabled_var.set(False)
+        self.eink_toggle_btn.config(text="eInk Disabled", bg="yellow", fg="black")
+        self.btn_refresh.config(state='disabled')
+        self.btn_set_dynamic.config(state='disabled')
+        self.btn_set_reading.config(state='disabled')
+        self._stop_refresh_timer()
+        self._destroy_floating_refresh_button()
+
+        if mode == "oled":
+            self.update_status("E-Ink display disabled")
+        else:
+            self.log_message(f"⚠ Detected display mode '{mode}', disabling eInk UI controls", level='warning')
+            self.update_status("Display state uncertain - controls disabled")
+
+        return state
+
     # === Event Handlers ===
     
     def on_eink_toggled(self):

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -1131,7 +1131,17 @@ class EInkControlGUI:
             return
 
         while conn.poll():
-            message = conn.recv()
+            try:
+                message = conn.recv()
+            except (EOFError, OSError):
+                self.log_message("Event watcher connection closed", level='warning')
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                self._event_watcher_conn = None
+                return
+
             event_type, payload = message if isinstance(message, tuple) and len(message) == 2 else (None, None)
             if event_type in ("lid", "randr"):
                 self.root.after(0, self._reconcile_from_live_state)

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -658,6 +658,7 @@ class EInkControlGUI:
             if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
                 self.update_status("Connected to helper daemon")
                 self.log_message("Connected to helper daemon")
+                self.sync_ui_from_display_state()
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -686,6 +687,7 @@ class EInkControlGUI:
             if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
                 self.log_message("✓ Reconnected to helper daemon")
                 self.update_status("Reconnected to helper daemon")
+                self.sync_ui_from_display_state()
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -876,15 +878,7 @@ class EInkControlGUI:
                 brightness_level=self.brightness_var.get(),
             )
             if ok:
-                self.eink_enabled_var.set(True)
-                self.eink_toggle_btn.config(text="eInk Enabled", bg="green", fg="white")
-                self.update_status("E-Ink display enabled")
-                self.btn_refresh.config(state='normal')
-                self.btn_set_dynamic.config(state='normal')
-                self.btn_set_reading.config(state='normal')
-                self._start_refresh_timer()
-                self.log_message("Creating floating refresh button...")
-                self.floating_refresh_button = FloatingRefreshButton(self.root, self.on_refresh_full, self.logger)
+                self.sync_ui_from_display_state()
             else:
                 self.log_message("⚠ Failed to switch to E-Ink", level='error')
             return
@@ -898,18 +892,7 @@ class EInkControlGUI:
             script_dir=os.path.dirname(os.path.abspath(__file__)),
         )
         if ok:
-            self._stop_refresh_timer()
-            if self.floating_refresh_button:
-                self.log_message("Destroying floating refresh button...")
-                self.floating_refresh_button.destroy()
-                self.floating_refresh_button = None
-
-            self.btn_refresh.config(state='disabled')
-            self.btn_set_dynamic.config(state='disabled')
-            self.btn_set_reading.config(state='disabled')
-            self.eink_enabled_var.set(False)
-            self.eink_toggle_btn.config(text="eInk Disabled", bg="yellow", fg="black")
-            self.update_status("E-Ink display disabled")
+            self.sync_ui_from_display_state()
         else:
             self.log_message("⚠ Failed to switch to OLED", level='error')
     

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -748,6 +748,8 @@ class EInkControlGUI:
                         self.log_message(f"EC access not available: {error_msg}", level='error')
                 else:
                     self.log_message("EC access verified - frontlight controls enabled")
+                    self.brightness_scale.config(state='normal')
+                    self.secure_boot_warning.grid_remove()
                     # Sync GUI with actual EC state
                     self.sync_frontlight_state()
 

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -1047,11 +1047,41 @@ class EInkControlGUI:
         else:
             EInkControlGUI._stop_lid_inhibitor(self)
 
+        previous_mode = self._live_sync_state.get("display_mode")
+        previous_lid_closed = self._live_sync_state.get("lid_closed")
+
         active_display = self.display_mgr.get_active_display()
         if active_display:
             rotation = self.display_mgr.get_display_rotation(active_display)
             if rotation in ("normal", "left"):
                 self._live_sync_state["last_eink_orientation"] = rotation
+
+            if mode == "eink":
+                desired_rotation = "left" if lid_closed else "normal"
+                no_effective_change = (
+                    previous_mode == mode
+                    and previous_lid_closed == lid_closed
+                    and rotation == desired_rotation
+                    and self._live_sync_state.get("last_eink_orientation") == desired_rotation
+                )
+
+                if not no_effective_change and rotation != desired_rotation:
+                    if self.display_mgr.set_display_rotation(active_display, desired_rotation):
+                        confirmed_rotation = self.display_mgr.get_display_rotation(active_display)
+                        if confirmed_rotation in ("normal", "left"):
+                            self._live_sync_state["last_eink_orientation"] = confirmed_rotation
+                        else:
+                            confirmed_rotation = desired_rotation
+                            self._live_sync_state["last_eink_orientation"] = confirmed_rotation
+
+                        if _apply_input_mode(self.logger, "eink"):
+                            ensure_touch_available(self.logger, "eink")
+                        else:
+                            self.log_message("⚠ Lid-driven rotation succeeded but input remap failed", level='warning')
+
+                        save_orientation_preference(self.logger, confirmed_rotation)
+                    else:
+                        self.log_message("⚠ Failed to apply lid-driven E-Ink rotation", level='warning')
 
         process = getattr(self, "_lid_inhibitor_process", None)
         inhibitor_running = bool(process is not None and process.poll() is None)

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -32,7 +32,13 @@ from datetime import datetime
 
 from HelperClient import HelperClient
 from DisplayManager import DisplayManager
-from mode_switch import get_display_state, switch_to_eink, switch_to_oled
+from mode_switch import (
+    _apply_input_mode,
+    get_display_state,
+    save_orientation_preference,
+    switch_to_eink,
+    switch_to_oled,
+)
 
 class FloatingRefreshButton:
     """Floating refresh button window that stays on top"""
@@ -220,6 +226,7 @@ class EInkControlGUI:
 
         # Display scaling (from settings)
         self.display_scale = settings['display_scale']
+        self.orientation_rotation = None
 
         # Build UI
         self.build_ui()
@@ -354,9 +361,18 @@ class EInkControlGUI:
                                       state='disabled')
         self.btn_refresh.grid(row=1, column=0, columnspan=2, padx=5, pady=5, sticky=(tk.W, tk.E))
 
+        # Orientation button
+        self.orientation_toggle_btn = ttk.Button(
+            display_frame,
+            text="Orientation: Landscape",
+            command=self.on_orientation_toggled,
+            state='disabled',
+        )
+        self.orientation_toggle_btn.grid(row=2, column=0, columnspan=2, padx=5, pady=5, sticky=(tk.W, tk.E))
+
         # Mode buttons (Dynamic and Reading)
         mode_frame = ttk.Frame(display_frame)
-        mode_frame.grid(row=2, column=0, columnspan=2, padx=5, pady=5, sticky=(tk.W, tk.E))
+        mode_frame.grid(row=3, column=0, columnspan=2, padx=5, pady=5, sticky=(tk.W, tk.E))
         mode_frame.columnconfigure(0, weight=1)
         mode_frame.columnconfigure(1, weight=1)
 
@@ -372,10 +388,10 @@ class EInkControlGUI:
 
         # Refresh period slider
         refresh_period_label = ttk.Label(display_frame, text="Refresh period (s):")
-        refresh_period_label.grid(row=3, column=0, sticky=tk.W, padx=5, pady=5)
+        refresh_period_label.grid(row=4, column=0, sticky=tk.W, padx=5, pady=5)
 
         refresh_period_container = ttk.Frame(display_frame)
-        refresh_period_container.grid(row=3, column=1, sticky=(tk.W, tk.E), padx=5, pady=5)
+        refresh_period_container.grid(row=4, column=1, sticky=(tk.W, tk.E), padx=5, pady=5)
         refresh_period_container.columnconfigure(0, weight=1)
 
         self.refresh_period_var = tk.IntVar(value=15)
@@ -390,10 +406,10 @@ class EInkControlGUI:
 
         # Display scale slider
         scale_label = ttk.Label(display_frame, text="Display Scale:")
-        scale_label.grid(row=4, column=0, sticky=tk.W, padx=5, pady=5)
+        scale_label.grid(row=5, column=0, sticky=tk.W, padx=5, pady=5)
 
         scale_container = ttk.Frame(display_frame)
-        scale_container.grid(row=4, column=1, sticky=(tk.W, tk.E), padx=5, pady=5)
+        scale_container.grid(row=5, column=1, sticky=(tk.W, tk.E), padx=5, pady=5)
 
         # Autoswitch theme checkbox
         self.autoswitch_theme_var = tk.BooleanVar(value=True)
@@ -403,7 +419,7 @@ class EInkControlGUI:
             variable=self.autoswitch_theme_var,
             command=self.on_autoswitch_theme_changed
         )
-        self.autoswitch_theme_checkbox.grid(row=5, column=0, columnspan=2, sticky=tk.W, padx=5, pady=5)
+        self.autoswitch_theme_checkbox.grid(row=6, column=0, columnspan=2, sticky=tk.W, padx=5, pady=5)
         scale_container.columnconfigure(0, weight=1)
 
         self.scale_var = tk.DoubleVar(value=1.75)
@@ -659,6 +675,7 @@ class EInkControlGUI:
                 self.update_status("Connected to helper daemon")
                 self.log_message("Connected to helper daemon")
                 self.sync_ui_from_display_state()
+                EInkControlGUI.sync_orientation_from_display_state(self)
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -688,6 +705,7 @@ class EInkControlGUI:
                 self.log_message("✓ Reconnected to helper daemon")
                 self.update_status("Reconnected to helper daemon")
                 self.sync_ui_from_display_state()
+                EInkControlGUI.sync_orientation_from_display_state(self)
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -832,6 +850,68 @@ class EInkControlGUI:
         self.floating_refresh_button.destroy()
         self.floating_refresh_button = None
 
+    def _orientation_label_from_rotation(self, rotation):
+        return "Portrait" if rotation == "left" else "Landscape"
+
+    def sync_orientation_from_display_state(self):
+        button = getattr(self, "orientation_toggle_btn", None)
+        if button is None:
+            return None
+
+        active_display = self.display_mgr.get_active_display()
+        if not active_display:
+            button.config(state='disabled')
+            self.log_message("⚠ No active display for orientation sync", level='warning')
+            return None
+
+        rotation = self.display_mgr.get_display_rotation(active_display)
+        if rotation not in ("normal", "left"):
+            button.config(state='disabled')
+            self.log_message(f"⚠ Unsupported live rotation '{rotation}' on {active_display}", level='warning')
+            return None
+
+        self.orientation_rotation = rotation
+        label = EInkControlGUI._orientation_label_from_rotation(self, rotation)
+        button.config(text=f"Orientation: {label}", state='normal')
+        return rotation
+
+    def on_orientation_toggled(self):
+        active_display = self.display_mgr.get_active_display()
+        if not active_display:
+            self.log_message("⚠ Cannot rotate: no active display", level='error')
+            return
+
+        current_rotation = self.display_mgr.get_display_rotation(active_display)
+        if current_rotation not in ("normal", "left"):
+            current_rotation = self.orientation_rotation
+
+        if current_rotation not in ("normal", "left"):
+            self.log_message("⚠ Cannot rotate: unknown current orientation", level='error')
+            return
+
+        target_rotation = "left" if current_rotation == "normal" else "normal"
+        if not self.display_mgr.set_display_rotation(active_display, target_rotation):
+            self.log_message("⚠ Failed to apply orientation rotation", level='error')
+            return
+
+        confirmed_rotation = self.display_mgr.get_display_rotation(active_display)
+        if confirmed_rotation not in ("normal", "left"):
+            self.log_message("⚠ Rotation applied but live orientation could not be confirmed", level='error')
+            return
+
+        self.orientation_rotation = confirmed_rotation
+        label = EInkControlGUI._orientation_label_from_rotation(self, confirmed_rotation)
+        self.orientation_toggle_btn.config(text=f"Orientation: {label}", state='normal')
+
+        mode = get_display_state(self.display_mgr).get("mode")
+        remap_target = mode if mode in ("eink", "oled") else None
+        if remap_target is None or not _apply_input_mode(self.logger, remap_target):
+            self.log_message("⚠ Rotation succeeded but input remap failed", level='warning')
+
+        save_orientation_preference(self.logger, confirmed_rotation)
+        self.update_status(f"Orientation set to {label}")
+        self.log_message(f"✓ Orientation set to {label}")
+
     def sync_ui_from_display_state(self):
         state = get_display_state(self.display_mgr)
         mode = state["mode"]
@@ -845,6 +925,7 @@ class EInkControlGUI:
             self._start_refresh_timer()
             self._ensure_floating_refresh_button()
             self.update_status("E-Ink display enabled")
+            EInkControlGUI.sync_orientation_from_display_state(self)
             return state
 
         self.eink_enabled_var.set(False)
@@ -861,6 +942,7 @@ class EInkControlGUI:
             self.log_message(f"⚠ Detected display mode '{mode}', disabling eInk UI controls", level='warning')
             self.update_status("Display state uncertain - controls disabled")
 
+        EInkControlGUI.sync_orientation_from_display_state(self)
         return state
 
     # === Event Handlers ===

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -694,11 +694,10 @@ class EInkControlGUI:
             if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
                 self.update_status("Connected to helper daemon")
                 self.log_message("Connected to helper daemon")
-                self.sync_ui_from_display_state()
-                EInkControlGUI.sync_orientation_from_display_state(self)
                 EInkControlGUI._start_event_watcher(self)
                 if getattr(self, "_event_watcher_poll_job", None) is None:
                     EInkControlGUI._schedule_event_watcher_poll(self)
+                self._reconcile_from_live_state()
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -727,11 +726,10 @@ class EInkControlGUI:
             if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
                 self.log_message("✓ Reconnected to helper daemon")
                 self.update_status("Reconnected to helper daemon")
-                self.sync_ui_from_display_state()
-                EInkControlGUI.sync_orientation_from_display_state(self)
                 EInkControlGUI._start_event_watcher(self)
                 if getattr(self, "_event_watcher_poll_job", None) is None:
                     EInkControlGUI._schedule_event_watcher_poll(self)
+                self._reconcile_from_live_state()
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -882,7 +880,7 @@ class EInkControlGUI:
             return
 
         self._last_activation_reconcile_at = now
-        reconcile_touch(self.logger, self.display_mgr, reason="window_activation")
+        self._reconcile_from_live_state()
 
     def _ensure_floating_refresh_button(self):
         if self.floating_refresh_button:
@@ -1062,6 +1060,10 @@ class EInkControlGUI:
         finally:
             self._lid_inhibitor_process = None
 
+    # Single policy owner for live E-Ink usability.
+    # Startup/reconnect/mode-switch/lid/RandR/activation triggers must feed into this
+    # reconciler instead of duplicating touch, inhibitor, or orientation policy elsewhere.
+    # This function is intentionally idempotent and safe to call frequently.
     def _reconcile_from_live_state(self):
         state = get_display_state(self.display_mgr)
         mode = state.get("mode", "unknown")
@@ -1208,7 +1210,7 @@ class EInkControlGUI:
                 brightness_level=self.brightness_var.get(),
             )
             if ok:
-                self.sync_ui_from_display_state()
+                self._reconcile_from_live_state()
             else:
                 self.log_message("⚠ Failed to switch to E-Ink", level='error')
             return
@@ -1222,7 +1224,7 @@ class EInkControlGUI:
             script_dir=os.path.dirname(os.path.abspath(__file__)),
         )
         if ok:
-            self.sync_ui_from_display_state()
+            self._reconcile_from_live_state()
         else:
             self.log_message("⚠ Failed to switch to OLED", level='error')
     

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -24,10 +24,10 @@ import subprocess
 import sys
 import os
 import time
-import threading
 import logging
 import webbrowser
 import json
+import grp
 from datetime import datetime
 
 from HelperClient import HelperClient
@@ -169,7 +169,7 @@ class EInkControlGUI:
     VERSION = "0.1.0 alpha"
 
     # Configuration
-    SOCKET_PATH = '/tmp/tinta4plus.sock'
+    SOCKET_PATH = '/run/tinta4plus.sock'
     KEEPALIVE_INTERVAL = 2.4  # seconds (send keepalive every 2.4s, watchdog is 20s)
     SOCKET_TIMEOUT = 10.0  # seconds
     CONFIG_DIR = os.path.expanduser("~/.config/Tinta4Plus")
@@ -195,11 +195,11 @@ class EInkControlGUI:
         self.root = root
         self.root.title("ThinkBook E-Ink Control")
         self.root.geometry("600x700")
+        self._set_window_icon()
 
         # Helper client
         self.helper = HelperClient(logger)
         self.keepalive_after_id = None
-        self.helper_process = None
 
         # Managers
         self.display_mgr = DisplayManager(logger)
@@ -576,88 +576,141 @@ class EInkControlGUI:
     def show_info_dialog(self, message):
         """Show info dialog"""
         messagebox.showinfo("Information", message)
-    
-    def initialize_helper(self):
-        """Initialize connection to helper daemon"""
-        # First try to connect to existing helper
-        if os.path.exists(self.SOCKET_PATH):
-            try:
-                if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
-                    self.update_status("Connected to helper daemon")
-                    self.log_message("Connected to existing helper daemon")
-                    self.start_keepalive()
-                    return
-            except Exception as e:
-                self.log_message(f"Failed to connect to existing socket: {e}")
-                # Remove stale socket
-                try:
-                    os.remove(self.SOCKET_PATH)
-                except:
-                    pass
-        
-        # No existing helper, launch it
-        self.log_message("Helper daemon not found, launching...")
-        self.update_status("Launching helper daemon (password required)...")
-        
-        # Launch helper via pkexec in background
-        threading.Thread(target=self._launch_helper_thread, daemon=True).start()
-    
-    def _launch_helper_thread(self):
-        """Launch helper daemon in background thread"""
-        try:
-            # Determine helper script path
-            helper_path = self.HELPER_SCRIPT
-            
-            # If not installed, try relative to this script
-            if not os.path.exists(helper_path):
-                script_dir = os.path.dirname(os.path.abspath(__file__))
-                helper_path = os.path.join(script_dir, 'thinkbook-eink-helper.py')
-            
-            if not os.path.exists(helper_path):
-                self.root.after(0, self._helper_launch_failed, "Helper script not found")
-                return
-            
-            # Launch via pkexec (will show password prompt)
-            self.helper_process = subprocess.Popen(
-                ['pkexec', 'python3', helper_path],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
-            )
-            
-            # Wait a moment for helper to start
-            time.sleep(1.5)
-            
-            # Try to connect
-            max_attempts = 10
-            for attempt in range(max_attempts):
-                if os.path.exists(self.SOCKET_PATH):
-                    if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
-                        self.root.after(0, self._helper_launch_success)
-                        return
-                time.sleep(0.5)
-            
-            self.root.after(0, self._helper_launch_failed, 
-                          "Helper started but socket not available")
-            
-        except Exception as e:
-            self.root.after(0, self._helper_launch_failed, str(e))
-    
-    def _helper_launch_success(self):
-        """Called when helper successfully launched"""
-        self.update_status("Connected to helper daemon")
-        self.log_message("Helper daemon launched successfully")
-        self.start_keepalive()
 
-        # Check EC status
-        self.root.after(500, self.check_ec_status)
+    def _set_window_icon(self):
+        """Set window icon from common system icon paths if available."""
+        icon_candidates = [
+            "/usr/share/icons/elementary-xfce/apps/48/preferences-desktop-display.png",
+            "/usr/share/icons/HighContrast/48x48/apps/preferences-desktop-display.png",
+            "/usr/share/icons/HighContrast/32x32/apps/preferences-desktop-display.png",
+            "/usr/share/icons/hicolor/48x48/status/display-brightness.png",
+        ]
+
+        for icon_path in icon_candidates:
+            if os.path.exists(icon_path):
+                try:
+                    icon_image = tk.PhotoImage(file=icon_path)
+                    self.root.iconphoto(True, icon_image)
+                    self.root._tinta_icon_image = icon_image
+                    self.logger.info(f"Using window icon: {icon_path}")
+                    return
+                except Exception:
+                    continue
     
-    def _helper_launch_failed(self, error):
-        """Called when helper launch failed"""
-        self.update_status(f"Failed to launch helper: {error}", error=True)
-        self.log_message(f"ERROR: Failed to launch helper - {error}", level='error')
+    def _get_script_dir(self):
+        return os.path.dirname(os.path.abspath(__file__))
+
+    def _get_installer_path(self):
+        return os.path.join(self._get_script_dir(), 'scripts', 'install-systemd-helper-root.sh')
+
+    def _needs_helper_install_or_upgrade(self):
+        """Use installer --check mode to detect drift or missing setup."""
+        installer = self._get_installer_path()
+        if not os.path.exists(installer):
+            return True, f"Installer not found: {installer}"
+
+        user_name = os.environ.get('SUDO_USER') or os.environ.get('USER') or 'taras'
+        command = [installer, '--check', '--source-dir', self._get_script_dir(), '--user', user_name]
+        result = subprocess.run(command, capture_output=True, text=True)
+
+        if result.returncode == 0:
+            return False, None
+
+        if result.returncode == 1:
+            return True, None
+
+        details = (result.stderr or result.stdout or '').strip()
+        return True, details or f"Check failed with exit code {result.returncode}"
+
+    def _is_current_process_in_helper_group(self):
+        """Return True when this running process has tinta4plus group in its group list."""
+        try:
+            helper_group = grp.getgrnam('tinta4plus')
+        except KeyError:
+            return False
+
+        return helper_group.gr_gid in os.getgroups()
+
+    def _run_helper_installer(self):
+        installer = self._get_installer_path()
+        if not os.path.exists(installer):
+            return False, f"Installer not found: {installer}"
+
+        user_name = os.environ.get('SUDO_USER') or os.environ.get('USER') or 'taras'
+        command = ['pkexec', installer, '--user', user_name, '--source-dir', self._get_script_dir()]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or '').strip()
+            return False, details or f"Installer failed with exit code {result.returncode}"
+
+        return True, None
+
+    def _prompt_install_or_upgrade(self):
+        needs_install, check_error = self._needs_helper_install_or_upgrade()
+        if check_error:
+            self.log_message(f"WARNING: Helper check failed: {check_error}", level='warning')
+
+        if not needs_install and self._is_current_process_in_helper_group():
+            return True
+
+        if needs_install:
+            prompt = (
+                "Tinta4Plus needs to install or update the system helper service.\n\n"
+                "This is a one-time privileged action using pkexec.\n"
+                "Install now?"
+            )
+        else:
+            prompt = (
+                "Your user is not active in the 'tinta4plus' group in this session.\n\n"
+                "Tinta4Plus can refresh permissions via installer now, then you'll need to re-login\n"
+                "and restart the app. Continue?"
+            )
+
+        install_now = messagebox.askyesno("Install privileged helper", prompt)
+        if not install_now:
+            return False
+
+        self.update_status("Installing/updating helper service (password required)...")
+        self.log_message("Installing/updating helper service via pkexec...")
+        ok, error = self._run_helper_installer()
+        if not ok:
+            self.log_message(f"ERROR: Helper install failed - {error}", level='error')
+            self.show_error_dialog(f"Helper install failed:\n\n{error}")
+            return False
+
+        if not self._is_current_process_in_helper_group():
+            self.show_info_dialog(
+                "Helper service installed/updated.\n\n"
+                "You must log out and log back in (or run 'newgrp tinta4plus' from a shell)\n"
+                "then restart Tinta4Plus."
+            )
+            self.log_message("Group membership update requires re-login before reconnect", level='warning')
+            return False
+
+        self.log_message("✓ Helper service installed/updated")
+        return True
+
+    def initialize_helper(self):
+        """Initialize connection to systemd socket-activated helper daemon."""
+        if not self._prompt_install_or_upgrade():
+            self.update_status("Helper service not installed")
+            return
+
+        try:
+            if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
+                self.update_status("Connected to helper daemon")
+                self.log_message("Connected to helper daemon")
+                self.start_keepalive()
+                self.root.after(500, self.check_ec_status)
+                return
+        except Exception as e:
+            self.log_message(f"Failed to connect to helper socket: {e}", level='error')
+
+        self.update_status("Failed to connect to helper daemon", error=True)
         self.show_error_dialog(
-            f"Failed to launch helper daemon:\n\n{error}\n\n"
-            "Make sure you entered the correct password."
+            "Could not connect to helper daemon at /run/tinta4plus.sock.\n\n"
+            "Run installer or check:\n"
+            "  systemctl status tinta4plus-helper.socket"
         )
     
     def start_keepalive(self):
@@ -713,51 +766,39 @@ class EInkControlGUI:
             self.attempt_helper_restart()
     
     def attempt_helper_restart(self):
-        """Attempt to restart the helper daemon with better error recovery"""
-        # Cancel any existing keepalive
+        """Attempt to reconnect to systemd socket-activated helper."""
         if self.keepalive_after_id:
             self.root.after_cancel(self.keepalive_after_id)
             self.keepalive_after_id = None
-        
-        self.log_message("Attempting to restart helper daemon...")
-        
-        # Disconnect cleanly first
+
+        self.log_message("Attempting to reconnect to helper daemon...")
+
         try:
             if self.helper.is_connected():
                 self.helper.disconnect()
         except Exception as e:
             self.logger.debug(f"Error during disconnect: {e}")
-        
-        # Small delay to allow cleanup
+
         time.sleep(0.5)
-        
-        # Try to connect to existing socket first
-        if os.path.exists(self.SOCKET_PATH):
-            try:
-                if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
-                    self.log_message("✓ Reconnected to existing helper")
-                    self.update_status("Reconnected to helper daemon")
-                    self.start_keepalive()
-                    # Re-check EC status and sync frontlight state after reconnect
-                    self.root.after(500, self.check_ec_status)
-                    return
-            except Exception as e:
-                self.logger.debug(f"Failed to reconnect to existing socket: {e}")
-                # Get detailed error from helper client
-                last_error = self.helper.get_last_error()
-                if last_error:
-                    self.log_message(f"Connection error: {last_error}", level='error')
-                # Remove stale socket
-                try:
-                    os.remove(self.SOCKET_PATH)
-                    self.log_message("Removed stale socket file")
-                except Exception as e:
-                    self.logger.warning(f"Could not remove socket: {e}")
-        
-        # Need to launch new helper
-        self.log_message("Launching new helper daemon (password may be required)...")
-        self.update_status("Launching helper daemon...")
-        threading.Thread(target=self._launch_helper_thread, daemon=True).start()
+
+        try:
+            if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
+                self.log_message("✓ Reconnected to helper daemon")
+                self.update_status("Reconnected to helper daemon")
+                self.start_keepalive()
+                self.root.after(500, self.check_ec_status)
+                return
+        except Exception as e:
+            self.logger.debug(f"Failed to reconnect helper socket: {e}")
+
+        self.log_message("ERROR: Helper reconnection failed", level='error')
+        self.update_status("Helper disconnected", error=True)
+        self.show_error_dialog(
+            "Lost connection to helper daemon.\n\n"
+            "Check service status:\n"
+            "  systemctl status tinta4plus-helper.socket\n"
+            "  systemctl status tinta4plus-helper.service"
+        )
     
     def check_ec_status(self):
         """Check EC access status and disable frontlight controls if Secure Boot enabled"""
@@ -1218,17 +1259,9 @@ class EInkControlGUI:
         if self.keepalive_after_id:
             self.root.after_cancel(self.keepalive_after_id)
 
-        # Disconnect from helper (sends shutdown command)
+        # Disconnect from helper client socket
         if self.helper.is_connected():
             self.helper.disconnect()
-
-        # Terminate helper process if we launched it
-        if self.helper_process:
-            try:
-                self.helper_process.terminate()
-                self.helper_process.wait(timeout=2)
-            except:
-                pass
 
         self.root.destroy()
 
@@ -1407,7 +1440,7 @@ def show_disclaimer_dialog(parent=None):
 
 def main():
     """Entry point"""
-    HELPER_SCRIPT = '/usr/local/bin/HelperDaemon.py'  # Or use sys.argv[0] relative path
+    HELPER_SCRIPT = '/usr/local/lib/tinta4plus/HelperDaemon.py'
 
     # Setup logging
     log_handlers = [
@@ -1434,15 +1467,6 @@ def main():
 
     sys.excepthook = handle_exception
 
-    # Check if helper script exists
-    if not os.path.exists(HELPER_SCRIPT):
-        # Try relative path
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        alt_helper = os.path.join(script_dir, 'HelperDaemon.py')
-        if os.path.exists(alt_helper):
-            HELPER_SCRIPT = alt_helper
-            logger.info(f"Using helper at: {HELPER_SCRIPT}")
-    
     root = tk.Tk()
     root.withdraw()  # Hide the main window initially
 

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -28,12 +28,16 @@ import logging
 import webbrowser
 import json
 import grp
+from multiprocessing import Process, Pipe
 from datetime import datetime
+
+from event_watcher import watch_events
 
 from HelperClient import HelperClient
 from DisplayManager import DisplayManager
 from mode_switch import (
     _apply_input_mode,
+    ensure_touch_available,
     get_display_state,
     save_orientation_preference,
     switch_to_eink,
@@ -227,6 +231,18 @@ class EInkControlGUI:
         # Display scaling (from settings)
         self.display_scale = settings['display_scale']
         self.orientation_rotation = None
+
+        # Live state reconciliation + helper notifications
+        self._live_sync_state = {
+            "display_mode": None,
+            "lid_closed": None,
+            "inhibitor_running": False,
+            "last_eink_orientation": None,
+        }
+        self._event_watcher_conn = None
+        self._event_watcher_process = None
+        self._event_watcher_poll_job = None
+        self._lid_inhibitor_process = None
 
         # Build UI
         self.build_ui()
@@ -676,6 +692,9 @@ class EInkControlGUI:
                 self.log_message("Connected to helper daemon")
                 self.sync_ui_from_display_state()
                 EInkControlGUI.sync_orientation_from_display_state(self)
+                EInkControlGUI._start_event_watcher(self)
+                if getattr(self, "_event_watcher_poll_job", None) is None:
+                    EInkControlGUI._schedule_event_watcher_poll(self)
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -706,6 +725,9 @@ class EInkControlGUI:
                 self.update_status("Reconnected to helper daemon")
                 self.sync_ui_from_display_state()
                 EInkControlGUI.sync_orientation_from_display_state(self)
+                EInkControlGUI._start_event_watcher(self)
+                if getattr(self, "_event_watcher_poll_job", None) is None:
+                    EInkControlGUI._schedule_event_watcher_poll(self)
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -907,6 +929,8 @@ class EInkControlGUI:
         remap_target = mode if mode in ("eink", "oled") else None
         if remap_target is None or not _apply_input_mode(self.logger, remap_target):
             self.log_message("⚠ Rotation succeeded but input remap failed", level='warning')
+        else:
+            ensure_touch_available(self.logger, remap_target)
 
         save_orientation_preference(self.logger, confirmed_rotation)
         self.update_status(f"Orientation set to {label}")
@@ -944,6 +968,150 @@ class EInkControlGUI:
 
         EInkControlGUI.sync_orientation_from_display_state(self)
         return state
+
+    def _read_live_lid_state(self):
+        candidates = [
+            "/proc/acpi/button/lid/LID0/state",
+            "/proc/acpi/button/lid/LID/state",
+        ]
+        for path in candidates:
+            try:
+                with open(path, "r", encoding="utf-8") as handle:
+                    text = handle.read().lower()
+                if "closed" in text:
+                    return True
+                if "open" in text:
+                    return False
+            except FileNotFoundError:
+                continue
+            except Exception as e:
+                self.logger.debug(f"Failed reading lid state from {path}: {e}")
+
+        return False
+
+    def _start_lid_inhibitor(self):
+        process = getattr(self, "_lid_inhibitor_process", None)
+        if process is not None and process.poll() is None:
+            return
+
+        command = [
+            "systemd-inhibit",
+            "--what=handle-lid-switch",
+            "--who=Tinta4Plus",
+            "--why=Keep E-Ink active while lid events are managed by GUI",
+            "sleep",
+            "infinity",
+        ]
+
+        try:
+            self._lid_inhibitor_process = subprocess.Popen(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            self.log_message("Lid-close suspend inhibitor enabled")
+        except Exception as e:
+            self._lid_inhibitor_process = None
+            self.log_message(f"Failed to start lid-close inhibitor: {e}", level='warning')
+
+    def _stop_lid_inhibitor(self):
+        process = getattr(self, "_lid_inhibitor_process", None)
+        if process is None:
+            return
+
+        try:
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=1.0)
+            self.log_message("Lid-close suspend inhibitor disabled")
+        except Exception as e:
+            self.log_message(f"Failed to stop lid-close inhibitor cleanly: {e}", level='warning')
+        finally:
+            self._lid_inhibitor_process = None
+
+    def _reconcile_from_live_state(self):
+        state = get_display_state(self.display_mgr)
+        mode = state.get("mode", "unknown")
+        lid_closed = bool(EInkControlGUI._read_live_lid_state(self))
+
+        if not hasattr(self, "_live_sync_state") or not isinstance(self._live_sync_state, dict):
+            self._live_sync_state = {
+                "display_mode": None,
+                "lid_closed": None,
+                "inhibitor_running": False,
+                "last_eink_orientation": None,
+            }
+
+        if mode == "eink":
+            EInkControlGUI._start_lid_inhibitor(self)
+        else:
+            EInkControlGUI._stop_lid_inhibitor(self)
+
+        active_display = self.display_mgr.get_active_display()
+        if active_display:
+            rotation = self.display_mgr.get_display_rotation(active_display)
+            if rotation in ("normal", "left"):
+                self._live_sync_state["last_eink_orientation"] = rotation
+
+        process = getattr(self, "_lid_inhibitor_process", None)
+        inhibitor_running = bool(process is not None and process.poll() is None)
+
+        self._live_sync_state["display_mode"] = mode
+        self._live_sync_state["lid_closed"] = lid_closed
+        self._live_sync_state["inhibitor_running"] = inhibitor_running
+
+        # GUI is still updated from live state on Tk thread.
+        self.sync_ui_from_display_state()
+        return dict(self._live_sync_state)
+
+    def _start_event_watcher(self):
+        if getattr(self, "_event_watcher_process", None):
+            return
+
+        parent_conn, child_conn = Pipe(duplex=False)
+        process = Process(target=watch_events, args=(child_conn,), daemon=True)
+        process.start()
+        child_conn.close()
+
+        self._event_watcher_conn = parent_conn
+        self._event_watcher_process = process
+
+    def _stop_event_watcher(self):
+        conn = getattr(self, "_event_watcher_conn", None)
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            self._event_watcher_conn = None
+
+        process = getattr(self, "_event_watcher_process", None)
+        if process is not None:
+            try:
+                if process.is_alive():
+                    process.terminate()
+                process.join(timeout=1.0)
+            except Exception as e:
+                self.logger.debug(f"Failed stopping event watcher process: {e}")
+            self._event_watcher_process = None
+
+    def _drain_event_watcher_notifications(self):
+        conn = getattr(self, "_event_watcher_conn", None)
+        if conn is None:
+            return
+
+        while conn.poll():
+            message = conn.recv()
+            event_type, payload = message if isinstance(message, tuple) and len(message) == 2 else (None, None)
+            if event_type in ("lid", "randr"):
+                self.root.after(0, self._reconcile_from_live_state)
+                continue
+            if event_type == "error":
+                self.log_message(f"Event watcher error: {payload}", level='error')
+
+    def _schedule_event_watcher_poll(self):
+        EInkControlGUI._drain_event_watcher_notifications(self)
+        self._event_watcher_poll_job = self.root.after(250, lambda: EInkControlGUI._schedule_event_watcher_poll(self))
 
     # === Event Handlers ===
     
@@ -1137,6 +1305,13 @@ class EInkControlGUI:
 
         # Stop refresh timer
         self._stop_refresh_timer()
+
+        poll_job = getattr(self, "_event_watcher_poll_job", None)
+        if poll_job:
+            self.root.after_cancel(poll_job)
+            self._event_watcher_poll_job = None
+        EInkControlGUI._stop_event_watcher(self)
+        EInkControlGUI._stop_lid_inhibitor(self)
 
         # Disconnect from helper client socket
         if self.helper.is_connected():

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -171,7 +171,6 @@ class EInkControlGUI:
 
     # Configuration
     SOCKET_PATH = '/run/tinta4plus.sock'
-    KEEPALIVE_INTERVAL = 2.4  # seconds (send keepalive every 2.4s, watchdog is 20s)
     SOCKET_TIMEOUT = 10.0  # seconds
     CONFIG_DIR = os.path.expanduser("~/.config/Tinta4Plus")
     SETTINGS_FILE = os.path.join(os.path.expanduser("~/.config/Tinta4Plus"), "settings")
@@ -200,7 +199,6 @@ class EInkControlGUI:
 
         # Helper client
         self.helper = HelperClient(logger)
-        self.keepalive_after_id = None
 
         # Managers
         self.display_mgr = DisplayManager(logger)
@@ -660,7 +658,6 @@ class EInkControlGUI:
             if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
                 self.update_status("Connected to helper daemon")
                 self.log_message("Connected to helper daemon")
-                self.start_keepalive()
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -672,65 +669,9 @@ class EInkControlGUI:
             "Run installer or check:\n"
             "  systemctl status tinta4plus-helper.socket"
         )
-    
-    def start_keepalive(self):
-        """Start periodic keepalive messages"""
-        if self.keepalive_after_id:
-            self.root.after_cancel(self.keepalive_after_id)
-        
-        self.keepalive_after_id = self.root.after(
-            int(self.KEEPALIVE_INTERVAL * 1000),
-            self.send_keepalive
-        )
-        self.logger.info(f"Started keepalive timer ({self.KEEPALIVE_INTERVAL}s interval)")
-    
-    def send_keepalive(self):
-        """Send keepalive message to helper with improved error handling"""
-        if not self.helper.is_connected():
-            self.update_status("Helper disconnected - attempting restart...", error=True)
-            last_error = self.helper.get_last_error()
-            error_msg = f"Helper disconnected: {last_error}" if last_error else "Helper disconnected"
-            self.log_message(f"{error_msg}, attempting to restart...", level='error')
-            self.attempt_helper_restart()
-            return  # Don't schedule next keepalive
-        
-        try:
-            response = self.helper.send_command('keepalive')
-            if not response or not response.get('success'):
-                self.logger.warning(f"Keepalive failed: {response}")
-                self.log_message("Keepalive failed, restarting helper...", level='error')
-                self.attempt_helper_restart()
-                return
-            
-            # Log successful keepalive at debug level to avoid spam
-            self.logger.debug("Keepalive successful")
-            
-            # Schedule next keepalive
-            self.keepalive_after_id = self.root.after(
-                int(self.KEEPALIVE_INTERVAL * 1000),
-                self.send_keepalive
-            )
-            
-        except RuntimeError as e:
-            # Connection-related errors
-            self.logger.error(f"Keepalive connection error: {e}")
-            self.update_status("Helper connection lost - restarting...", error=True)
-            self.log_message(f"Connection error: {e}", level='error')
-            self.attempt_helper_restart()
-        
-        except Exception as e:
-            # Unexpected errors
-            self.logger.error(f"Keepalive unexpected error: {e}", exc_info=True)
-            self.update_status("Helper error - restarting...", error=True)
-            self.log_message(f"Unexpected error: {e}", level='error')
-            self.attempt_helper_restart()
-    
+
     def attempt_helper_restart(self):
         """Attempt to reconnect to systemd socket-activated helper."""
-        if self.keepalive_after_id:
-            self.root.after_cancel(self.keepalive_after_id)
-            self.keepalive_after_id = None
-
         self.log_message("Attempting to reconnect to helper daemon...")
 
         try:
@@ -745,7 +686,6 @@ class EInkControlGUI:
             if self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT):
                 self.log_message("✓ Reconnected to helper daemon")
                 self.update_status("Reconnected to helper daemon")
-                self.start_keepalive()
                 self.root.after(500, self.check_ec_status)
                 return
         except Exception as e:
@@ -1092,10 +1032,6 @@ class EInkControlGUI:
 
         # Stop refresh timer
         self._stop_refresh_timer()
-
-        # Stop keepalive
-        if self.keepalive_after_id:
-            self.root.after_cancel(self.keepalive_after_id)
 
         # Disconnect from helper client socket
         if self.helper.is_connected():

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -1580,12 +1580,17 @@ def setup_logger():
     logger.propagate = False
 
     stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    stream_handler.setFormatter(logging.Formatter('%(name)s - %(levelname)s - %(message)s'))
 
-    file_handler = logging.FileHandler(LOG_FILE, mode='a')
-    file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    handlers = [stream_handler]
+    try:
+        file_handler = logging.FileHandler(LOG_FILE, mode='a')
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        handlers.append(file_handler)
+    except Exception as e:
+        print(f"Warning: could not open {LOG_FILE} for append logging: {e}", file=sys.stderr)
 
-    logger.handlers = [stream_handler, file_handler]
+    logger.handlers = handlers
     return logger
 
 

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -797,6 +797,9 @@ class EInkControlGUI:
                     # Sync GUI with actual EC state
                     self.sync_frontlight_state()
 
+        except KeyboardInterrupt:
+            self.logger.info("Interrupted during EC status check; closing application")
+            self.on_closing()
         except Exception as e:
             self.logger.error(f"Failed to check EC status: {e}")
             self.log_message(f"Warning: Could not verify EC status: {e}", level='error')
@@ -814,6 +817,9 @@ class EInkControlGUI:
                     self.brightness_label.config(text=str(brightness))
                     self.log_message(f"Synced brightness level: {brightness}")
 
+        except KeyboardInterrupt:
+            self.logger.info("Interrupted during frontlight sync; closing application")
+            self.on_closing()
         except Exception as e:
             self.logger.warning(f"Failed to sync frontlight state: {e}")
             self.log_message(f"Warning: Could not sync frontlight state from EC", level='error')

--- a/Tinta4Plus.py
+++ b/Tinta4Plus.py
@@ -32,6 +32,7 @@ from datetime import datetime
 
 from HelperClient import HelperClient
 from DisplayManager import DisplayManager
+from mode_switch import switch_to_eink, switch_to_oled
 
 class FloatingRefreshButton:
     """Floating refresh button window that stays on top"""
@@ -237,47 +238,6 @@ class EInkControlGUI:
 
         # Initialize helper after short delay
         self.root.after(500, self.initialize_helper)
-
-    def set_xfce_theme(self, theme_name):
-        """Set XFCE theme programmatically.
-
-        Args:
-            theme_name: Theme name like 'HighContrast' or 'Adwaita-dark'
-
-        Returns:
-            bool: True if successful, False otherwise
-        """
-        try:
-            subprocess.run([
-                'xfconf-query',
-                '-c', 'xsettings',
-                '-p', '/Net/ThemeName',
-                '-s', theme_name
-            ], check=True, capture_output=True)
-            self.log_message(f"Switched to {theme_name} theme")
-            return True
-        except subprocess.CalledProcessError as e:
-            self.log_message(f"Failed to set theme: {e}", level='error')
-            return False
-        except FileNotFoundError:
-            self.log_message("xfconf-query not found (not running XFCE?)", level='error')
-            return False
-
-    def get_current_theme(self):
-        """Get the current XFCE theme.
-
-        Returns:
-            str: Current theme name, or None if failed
-        """
-        try:
-            result = subprocess.run([
-                'xfconf-query',
-                '-c', 'xsettings',
-                '-p', '/Net/ThemeName'
-            ], capture_output=True, text=True, check=True)
-            return result.stdout.strip()
-        except:
-            return None
 
     def load_settings(self):
         """Load settings from configuration file"""
@@ -916,178 +876,56 @@ class EInkControlGUI:
     # === Event Handlers ===
     
     def on_eink_toggled(self):
-        """Handle E-Ink display toggle with automatic eDP switching"""
-        enabled = self.eink_enabled_var.get()
-        # Toggle the state
-        enabled = not enabled
+        """Handle E-Ink display toggle with shared switch logic."""
+        enabling = not self.eink_enabled_var.get()
 
-        if enabled:
-            # Enabling E-Ink
-            self.log_message("Enabling E-Ink display...")
-
-            # Step 0: Switch to High Contrast theme if enabled
-            if self.autoswitch_theme_var.get():
-                self.set_xfce_theme(self.THEME_HIGH_CONTRAST)
-
-            # Step 1: Enable E-Ink on eDP-2 first
-            self.log_message(f"Enabling E-Ink display on {self.DISPLAY_EINK} with {self.display_scale}x scale...")
-            if self.display_mgr.enable_display(self.DISPLAY_EINK, scale=self.display_scale):
-                self.log_message(f"✓ E-Ink display ({self.DISPLAY_EINK}) enabled with {self.display_scale}x scale")
-            else:
-                self.log_message(f"⚠ Failed to enable E-Ink display on {self.DISPLAY_EINK}", level='error')
-
-            # Small delay to ensure display is fully enabled
-            time.sleep(1.0)
-
-            # Step 2: Enable E-Ink via USB TCON controller
-            response = self.execute_helper_command('enable-eink')
-
-            if response:
+        if enabling:
+            ok = switch_to_eink(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                scale=self.display_scale,
+                autoswitch_theme=self.autoswitch_theme_var.get(),
+                enable_frontlight=True,
+                brightness_level=self.brightness_var.get(),
+            )
+            if ok:
                 self.eink_enabled_var.set(True)
                 self.eink_toggle_btn.config(text="eInk Enabled", bg="green", fg="white")
                 self.update_status("E-Ink display enabled")
-
-                # Enable refresh button and mode buttons
                 self.btn_refresh.config(state='normal')
                 self.btn_set_dynamic.config(state='normal')
                 self.btn_set_reading.config(state='normal')
-
-                # Step 3: Enable frontlight automatically with current brightness
-                self.log_message("Enabling frontlight for E-Ink display...")
-                brightness_level = self.brightness_var.get()
-                frontlight_response = self.execute_helper_command('enable-frontlight',
-                                                                  brightness_level=brightness_level)
-                if frontlight_response:
-                    self.log_message(f"✓ Frontlight enabled with brightness {brightness_level}")
-                else:
-                    self.log_message("⚠ Failed to enable frontlight (may not be available)", level='error')
-
-                # Small delay before disabling OLED
-                time.sleep(0.5)
-
-                # Step 4: Disable OLED display on eDP-1 as the last step
-                self.log_message(f"Disabling OLED display on {self.DISPLAY_OLED}...")
-                if self.display_mgr.disable_display(self.DISPLAY_OLED):
-                    self.log_message(f"✓ OLED display ({self.DISPLAY_OLED}) disabled")
-                else:
-                    self.log_message(f"⚠ Failed to disable OLED display on {self.DISPLAY_OLED}", level='error')
-
-                # Start periodic refresh timer if configured
                 self._start_refresh_timer()
-
-                # Create floating refresh button
                 self.log_message("Creating floating refresh button...")
-                self.floating_refresh_button = FloatingRefreshButton(
-                    self.root,
-                    self.on_refresh_full,
-                    self.logger
-                )
+                self.floating_refresh_button = FloatingRefreshButton(self.root, self.on_refresh_full, self.logger)
+            else:
+                self.log_message("⚠ Failed to switch to E-Ink", level='error')
+            return
 
-        else:
-            # Disabling E-Ink
-            self.log_message("Preparing to disable E-Ink display...")
-
-            # Step 1: Stop periodic refresh timer first
+        ok = switch_to_oled(
+            self.display_mgr,
+            self.helper,
+            self.logger,
+            scale=self.display_scale,
+            autoswitch_theme=self.autoswitch_theme_var.get(),
+            script_dir=os.path.dirname(os.path.abspath(__file__)),
+        )
+        if ok:
             self._stop_refresh_timer()
-
-            # Step 2: Destroy floating refresh button
             if self.floating_refresh_button:
                 self.log_message("Destroying floating refresh button...")
                 self.floating_refresh_button.destroy()
                 self.floating_refresh_button = None
 
-            # Step 3: Disable refresh button and mode buttons
             self.btn_refresh.config(state='disabled')
             self.btn_set_dynamic.config(state='disabled')
             self.btn_set_reading.config(state='disabled')
-
-            # Step 4: Display privacy image on E-Ink screen
-            image_path = self.EINK_DISABLED_IMAGE
-            if not os.path.exists(image_path):
-                # Try in script directory
-                script_dir = os.path.dirname(os.path.abspath(__file__))
-                image_path = os.path.join(script_dir, self.EINK_DISABLED_IMAGE)
-
-            if os.path.exists(image_path):
-                self.log_message(f"Displaying privacy image on {self.DISPLAY_EINK}...")
-                self.eink_image_process = self.display_mgr.display_fullscreen_image(
-                    self.DISPLAY_EINK,
-                    image_path
-                )
-
-                if self.eink_image_process:
-                    # Wait for image to fully render on E-Ink
-                    self.log_message("Waiting for image to render...")
-                    time.sleep(0.5)  # Give E-Ink time to display the image
-                else:
-                    self.log_message("Warning: Could not display privacy image", level='error')
-            else:
-                self.log_message(f"Warning: Privacy image not found: {self.EINK_DISABLED_IMAGE}", level='error')
-
-            # Step 4: Disable E-Ink via USB controller
-            self.log_message("Disabling E-Ink display via USB controller...")
-            response = self.execute_helper_command('disable-eink')
-
-            if response:
-                self.eink_enabled_var.set(False)
-                self.eink_toggle_btn.config(text="eInk Disabled", bg="yellow", fg="black")
-                self.update_status("E-Ink display disabled")
-
-                # Disable frontlight automatically when switching to OLED
-                self.log_message("Disabling frontlight...")
-                frontlight_response = self.execute_helper_command('disable-frontlight')
-                if frontlight_response:
-                    self.log_message("✓ Frontlight disabled")
-                else:
-                    self.log_message("⚠ Failed to disable frontlight", level='error')
-
-                time.sleep(2.0)  # Give E-Ink time to display the image
-
-                # Kill the image viewer process (image is now persisted on E-Ink)
-                if self.eink_image_process:
-                    try:
-                        self.eink_image_process.terminate()
-                        self.eink_image_process.wait(timeout=2)
-                        self.log_message("Closed image viewer (image persisted on E-Ink)")
-                    except:
-                        try:
-                            self.eink_image_process.kill()
-                        except:
-                            pass
-                    self.eink_image_process = None
-
-                # Step 1: Enable OLED display on eDP-1 first
-                self.log_message(f"Enabling OLED display on {self.DISPLAY_OLED} with {self.display_scale}x scale...")
-                if self.display_mgr.enable_display(self.DISPLAY_OLED, scale=self.display_scale):
-                    self.log_message(f"✓ OLED display ({self.DISPLAY_OLED}) enabled with {self.display_scale}x scale")
-                else:
-                    self.log_message(f"⚠ Failed to enable OLED display on {self.DISPLAY_OLED}", level='error')
-
-                # Small delay to ensure OLED is fully enabled
-                time.sleep(1.0)
-
-                # Step 5: Disable E-Ink on eDP-2 as the last step
-                self.log_message(f"Disabling E-Ink display on {self.DISPLAY_EINK}...")
-                if self.display_mgr.disable_display(self.DISPLAY_EINK):
-                    self.log_message(f"✓ E-Ink display ({self.DISPLAY_EINK}) disabled")
-                else:
-                    self.log_message(f"⚠ Failed to disable E-Ink display on {self.DISPLAY_EINK}", level='error')
-
-                # Step 6: Switch to Adwaita-dark theme if enabled
-                if self.autoswitch_theme_var.get():
-                    self.set_xfce_theme(self.THEME_ADWAITA_DARK)
-            else:
-                # Failed to disable - kill image viewer
-                if self.eink_image_process:
-                    try:
-                        self.eink_image_process.terminate()
-                        self.eink_image_process.wait(timeout=2)
-                    except:
-                        try:
-                            self.eink_image_process.kill()
-                        except:
-                            pass
-                    self.eink_image_process = None
+            self.eink_enabled_var.set(False)
+            self.eink_toggle_btn.config(text="eInk Disabled", bg="yellow", fg="black")
+            self.update_status("E-Ink display disabled")
+        else:
+            self.log_message("⚠ Failed to switch to OLED", level='error')
     
     def on_refresh_full(self):
         """Perform full E-Ink refresh"""

--- a/contrib/systemd/tinta4plus-helper.service
+++ b/contrib/systemd/tinta4plus-helper.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Tinta4Plus privileged helper daemon
+Requires=tinta4plus-helper.socket
+After=tinta4plus-helper.socket
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/lib/tinta4plus/HelperDaemon.py
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/tinta4plus-helper.socket
+++ b/contrib/systemd/tinta4plus-helper.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tinta4Plus privileged helper socket
+
+[Socket]
+ListenStream=/run/tinta4plus.sock
+SocketMode=0660
+SocketGroup=tinta4plus
+RemoveOnStop=yes
+
+[Install]
+WantedBy=sockets.target

--- a/contrib/systemd/user/tinta4plus-disable-eink-output.service
+++ b/contrib/systemd/user/tinta4plus-disable-eink-output.service
@@ -4,9 +4,11 @@ After=default.target
 
 [Service]
 Type=oneshot
-# xrandr requires the user's X11 login environment, especially DISPLAY/XAUTHORITY.
-# This unit is installed as a systemd --user unit so it runs in the desktop session.
-ExecStart=/usr/bin/xrandr --output eDP-2 --off --output eDP-1 --auto --primary
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=%h/.Xauthority
+# xrandr requires the user's X11 login environment. LightDM/XFCE can start
+# systemd --user units before X is ready, so retry until the display opens.
+ExecStart=/bin/sh -c 'until /usr/bin/xrandr --output eDP-2 --off --output eDP-1 --auto --primary; do sleep 1; done'
 
 [Install]
 WantedBy=default.target

--- a/contrib/systemd/user/tinta4plus-disable-eink-output.service
+++ b/contrib/systemd/user/tinta4plus-disable-eink-output.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable E-Ink X11 output at login
+After=default.target
+
+[Service]
+Type=oneshot
+# xrandr requires the user's X11 login environment, especially DISPLAY/XAUTHORITY.
+# This unit is installed as a systemd --user unit so it runs in the desktop session.
+ExecStart=/usr/bin/xrandr --output eDP-2 --off --output eDP-1 --auto --primary
+
+[Install]
+WantedBy=default.target

--- a/debug-display-switch-sensor.py
+++ b/debug-display-switch-sensor.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import os
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TextIO
+
+IIO_ROOT = Path("/sys/bus/iio/devices")
+INPUT_DEVICES = Path("/proc/bus/input/devices")
+
+
+@dataclass(slots=True, frozen=True)
+class HingeDevice:
+    sysfs: Path
+    devnode: Path
+    scale: float
+    labels: tuple[str, str, str]
+
+
+@dataclass(slots=True, frozen=True)
+class AppConfig:
+    logfile: Path
+    duration_s: float | None
+    poll_interval_s: float
+    include_input: bool
+
+
+def ts() -> str:
+    return datetime.now().astimezone().isoformat(timespec="milliseconds")
+
+
+def find_hinge_device() -> HingeDevice:
+    for d in IIO_ROOT.glob("iio:device*"):
+        namef = d / "name"
+        if not namef.exists() or namef.read_text().strip() != "hinge":
+            continue
+        scale = float((d / "in_angl_scale").read_text().strip())
+        labels = tuple((d / f"in_angl{i}_label").read_text().strip() for i in range(3))
+        return HingeDevice(sysfs=d, devnode=Path("/dev") / d.name, scale=scale, labels=labels)  # type: ignore[arg-type]
+    raise RuntimeError("No hinge IIO device found")
+
+
+def find_tablet_mode_event() -> str | None:
+    if not INPUT_DEVICES.exists():
+        return None
+    blocks = INPUT_DEVICES.read_text(errors="ignore").split("\n\n")
+    for block in blocks:
+        if 'Name="Lenovo Yoga Tablet Mode Control switch"' not in block:
+            continue
+        for token in block.split():
+            if token.startswith("event") and token[5:].isdigit():
+                return f"/dev/input/{token}"
+    return None
+
+
+class CsvSink:
+    def __init__(self, f: TextIO) -> None:
+        self._writer = csv.writer(f)
+        self._writer.writerow([
+            "timestamp",
+            "source",
+            "raw0",
+            "raw1",
+            "raw2",
+            "deg0",
+            "deg1",
+            "deg2",
+            "detail",
+        ])
+
+    def row(self, values: list[str]) -> None:
+        self._writer.writerow(values)
+
+
+class HingeSampler:
+    def __init__(self, dev: HingeDevice, sink: CsvSink) -> None:
+        self.dev = dev
+        self.sink = sink
+        self._last: tuple[int, int, int] | None = None
+
+    def _read_raw(self) -> tuple[int, int, int]:
+        return tuple(int((self.dev.sysfs / f"in_angl{i}_raw").read_text().strip()) for i in range(3))  # type: ignore[return-value]
+
+    def _emit(self, raws: tuple[int, int, int], detail: str) -> None:
+        if raws == self._last:
+            return
+        deg = tuple(v * self.dev.scale * 57.29577951308232 for v in raws)
+        t = ts()
+        self.sink.row([
+            t,
+            "iio",
+            str(raws[0]),
+            str(raws[1]),
+            str(raws[2]),
+            f"{deg[0]:.2f}",
+            f"{deg[1]:.2f}",
+            f"{deg[2]:.2f}",
+            detail,
+        ])
+        print(f"{t} IIO {self.dev.labels[0]}={deg[0]:6.2f}° {self.dev.labels[1]}={deg[1]:6.2f}° {self.dev.labels[2]}={deg[2]:6.2f}°")
+        self._last = raws
+
+    async def run(self, poll_interval_s: float) -> None:
+        # Best effort event-driven wakeup via /dev/iio:* read.
+        # Some kernels return EINVAL here; we gracefully fall back to polling.
+        try:
+            fd = os.open(self.dev.devnode, os.O_RDONLY)
+            try:
+                while True:
+                    await asyncio.to_thread(os.read, fd, 20)  # block until sample-ish wakeup
+                    self._emit(self._read_raw(), "triggered")
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            print(f"{ts()} WARN iio event-read unavailable ({exc}); fallback poll={poll_interval_s}s", file=sys.stderr)
+            while True:
+                self._emit(self._read_raw(), "poll")
+                await asyncio.sleep(poll_interval_s)
+
+
+async def input_task(sink: CsvSink, devnode: str) -> None:
+    proc = await asyncio.create_subprocess_exec(
+        "libinput",
+        "debug-events",
+        "--device",
+        devnode,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    assert proc.stdout is not None
+    async for bline in proc.stdout:
+        line = bline.decode(errors="replace").rstrip("\n")
+        t = ts()
+        sink.row([t, "input", "", "", "", "", "", "", line])
+        print(f"{t} INPUT {line}")
+
+
+async def main_async(cfg: AppConfig) -> int:
+    hinge = find_hinge_device()
+    tablet_input = find_tablet_mode_event() if cfg.include_input else None
+
+    cfg.logfile.parent.mkdir(parents=True, exist_ok=True)
+    with cfg.logfile.open("w", newline="", encoding="utf-8") as f:
+        sink = CsvSink(f)
+        print(f"hinge={hinge.sysfs} dev={hinge.devnode} logfile={cfg.logfile}")
+        if tablet_input:
+            print(f"input={tablet_input}")
+        elif cfg.include_input:
+            print("input=not-found")
+
+        tasks = [asyncio.create_task(HingeSampler(hinge, sink).run(cfg.poll_interval_s))]
+        if tablet_input and shutil_which("libinput") and os.access(tablet_input, os.R_OK):
+            tasks.append(asyncio.create_task(input_task(sink, tablet_input)))
+        elif cfg.include_input:
+            print(f"{ts()} WARN input stream unavailable (install libinput / use sudo)", file=sys.stderr)
+
+        try:
+            if cfg.duration_s is None:
+                await asyncio.gather(*tasks)
+            else:
+                await asyncio.wait_for(asyncio.gather(*tasks), timeout=cfg.duration_s)
+        except asyncio.TimeoutError:
+            print(f"{ts()} done (duration reached)")
+        except asyncio.CancelledError:
+            pass
+        finally:
+            for t in tasks:
+                t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    return 0
+
+
+def shutil_which(cmd: str) -> str | None:
+    for p in os.environ.get("PATH", "").split(":"):
+        cand = Path(p) / cmd
+        if cand.exists() and os.access(cand, os.X_OK):
+            return str(cand)
+    return None
+
+
+def parse_args() -> AppConfig:
+    p = argparse.ArgumentParser(description="Debug display switch sensors (hinge + tablet mode)")
+    p.add_argument("logfile", nargs="?", default=f"/tmp/hinge-correlate-{datetime.now():%Y%m%d-%H%M%S}.csv")
+    p.add_argument("--duration", type=float, default=None, help="Auto-stop after N seconds")
+    p.add_argument("--poll-interval", type=float, default=0.05, help="Fallback poll interval in seconds")
+    p.add_argument("--no-input", action="store_true", help="Disable input event stream")
+    a = p.parse_args()
+    return AppConfig(
+        logfile=Path(a.logfile),
+        duration_s=a.duration,
+        poll_interval_s=a.poll_interval,
+        include_input=not a.no_input,
+    )
+
+
+def _install_signal_handlers(loop: asyncio.AbstractEventLoop) -> None:
+    for s in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(s, lambda: [t.cancel() for t in asyncio.all_tasks(loop)])
+        except NotImplementedError:
+            pass
+
+
+def main() -> int:
+    cfg = parse_args()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    _install_signal_handlers(loop)
+    try:
+        return loop.run_until_complete(main_async(cfg))
+    finally:
+        loop.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/debug-display-switch-sensor.py
+++ b/debug-display-switch-sensor.py
@@ -6,6 +6,7 @@ import asyncio
 import csv
 import os
 import signal
+import struct
 import sys
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,6 +15,11 @@ from typing import TextIO
 
 IIO_ROOT = Path("/sys/bus/iio/devices")
 INPUT_DEVICES = Path("/proc/bus/input/devices")
+
+EV_SYN = 0x00
+EV_SW = 0x05
+SW_TABLET_MODE = 0x01
+INPUT_EVENT_STRUCT = struct.Struct("llHHI")
 
 
 @dataclass(slots=True, frozen=True)
@@ -54,10 +60,36 @@ def find_tablet_mode_event() -> str | None:
     for block in blocks:
         if 'Name="Lenovo Yoga Tablet Mode Control switch"' not in block:
             continue
-        for token in block.split():
+        handlers_line = next((line for line in block.splitlines() if line.startswith("H: Handlers=")), "")
+        if not handlers_line:
+            continue
+        for token in handlers_line.removeprefix("H: Handlers=").split():
             if token.startswith("event") and token[5:].isdigit():
                 return f"/dev/input/{token}"
     return None
+
+
+def normalize_deg(value: float) -> float:
+    wrapped = value % 360.0
+    if wrapped > 180.0:
+        wrapped -= 360.0
+    return wrapped
+
+
+def decode_input_event(data: bytes) -> tuple[int, int, int]:
+    if len(data) != INPUT_EVENT_STRUCT.size:
+        raise ValueError(f"short read: {len(data)} < {INPUT_EVENT_STRUCT.size}")
+    _, _, event_type, code, value = INPUT_EVENT_STRUCT.unpack(data)
+    return event_type, code, int(value)
+
+
+def format_input_event_detail(event_type: int, code: int, value: int) -> str | None:
+    if event_type == EV_SYN:
+        return None
+    if event_type == EV_SW and code == SW_TABLET_MODE:
+        state = "tablet" if value else "laptop"
+        return f"SW_TABLET_MODE value={value} state={state}"
+    return f"event type=0x{event_type:02x} code=0x{code:02x} value={value}"
 
 
 class CsvSink:
@@ -91,7 +123,7 @@ class HingeSampler:
     def _emit(self, raws: tuple[int, int, int], detail: str) -> None:
         if raws == self._last:
             return
-        deg = tuple(v * self.dev.scale * 57.29577951308232 for v in raws)
+        deg = tuple(normalize_deg(v * self.dev.scale * 57.29577951308232) for v in raws)
         t = ts()
         self.sink.row([
             t,
@@ -126,20 +158,31 @@ class HingeSampler:
 
 
 async def input_task(sink: CsvSink, devnode: str) -> None:
-    proc = await asyncio.create_subprocess_exec(
-        "libinput",
-        "debug-events",
-        "--device",
-        devnode,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    assert proc.stdout is not None
-    async for bline in proc.stdout:
-        line = bline.decode(errors="replace").rstrip("\n")
-        t = ts()
-        sink.row([t, "input", "", "", "", "", "", "", line])
-        print(f"{t} INPUT {line}")
+    fd = os.open(devnode, os.O_RDONLY)
+    try:
+        while True:
+            data = await asyncio.to_thread(os.read, fd, INPUT_EVENT_STRUCT.size)
+            if not data:
+                await asyncio.sleep(0.01)
+                continue
+            while len(data) < INPUT_EVENT_STRUCT.size:
+                chunk = await asyncio.to_thread(os.read, fd, INPUT_EVENT_STRUCT.size - len(data))
+                if not chunk:
+                    break
+                data += chunk
+            if len(data) != INPUT_EVENT_STRUCT.size:
+                continue
+
+            event_type, code, value = decode_input_event(data)
+            detail = format_input_event_detail(event_type, code, value)
+            if detail is None:
+                continue
+
+            t = ts()
+            sink.row([t, "input", "", "", "", "", "", "", detail])
+            print(f"{t} INPUT {detail}")
+    finally:
+        os.close(fd)
 
 
 async def main_async(cfg: AppConfig) -> int:
@@ -156,10 +199,10 @@ async def main_async(cfg: AppConfig) -> int:
             print("input=not-found")
 
         tasks = [asyncio.create_task(HingeSampler(hinge, sink).run(cfg.poll_interval_s))]
-        if tablet_input and shutil_which("libinput") and os.access(tablet_input, os.R_OK):
+        if tablet_input and os.access(tablet_input, os.R_OK):
             tasks.append(asyncio.create_task(input_task(sink, tablet_input)))
         elif cfg.include_input:
-            print(f"{ts()} WARN input stream unavailable (install libinput / use sudo)", file=sys.stderr)
+            print(f"{ts()} WARN input stream unavailable (need read access to tablet switch event node)", file=sys.stderr)
 
         try:
             if cfg.duration_s is None:
@@ -176,14 +219,6 @@ async def main_async(cfg: AppConfig) -> int:
             await asyncio.gather(*tasks, return_exceptions=True)
 
     return 0
-
-
-def shutil_which(cmd: str) -> str | None:
-    for p in os.environ.get("PATH", "").split(":"):
-        cand = Path(p) / cmd
-        if cand.exists() and os.access(cand, os.X_OK):
-            return str(cand)
-    return None
 
 
 def parse_args() -> AppConfig:

--- a/docs/plans/2026-03-01-shared-mode-switching-cli-gui.md
+++ b/docs/plans/2026-03-01-shared-mode-switching-cli-gui.md
@@ -1,0 +1,29 @@
+# Shared mode switching for GUI + CLI (minimal plan)
+
+1. **Create shared module** (`mode_switch.py`)
+   - Move mode transitions there:
+     - switch to E-Ink
+     - switch to OLED
+   - Include:
+     - privacy image before E-Ink off
+     - XFCE theme switch (HighContrast/Adwaita-dark)
+
+2. **Use it from GUI**
+   - Replace transition logic in `Tinta4Plus.py` with calls to `mode_switch.py`
+   - Keep GUI-only behavior (buttons/timers/dialogs) in GUI file
+
+3. **Use it from CLI**
+   - Make `toggle-eink.py` call the same shared functions
+   - Keep CLI no-options, just toggle
+
+4. **Quick manual check**
+   - Toggle twice with CLI and confirm:
+     - E-Ink path works
+     - OLED path shows privacy image + theme changes
+
+5. **Config parity**
+   - Read `~/.config/Tinta4Plus/settings`
+   - Use `autoswitch_theme` and `display_scale` in CLI same as GUI
+   - Keep defaults if missing:
+     - `autoswitch_theme=True`
+     - `display_scale=1.75`

--- a/docs/plans/2026-03-05-http-over-unix-socket-migration.md
+++ b/docs/plans/2026-03-05-http-over-unix-socket-migration.md
@@ -1,25 +1,75 @@
-# HTTP over Unix Socket Migration (TL;DR)
+# HTTP over Unix Socket Migration (TL;DR + versioned endpoints)
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** switch helper protocol from custom length-prefix JSON to HTTP, on the same Unix socket (`/run/tinta4plus.sock`).
+**Goal:** replace custom length-prefixed socket protocol with HTTP over the same Unix socket (`/run/tinta4plus.sock`), using explicit versioned verb endpoints.
 
-**Keep unchanged:**
-- Socket path
+## API contract (v1)
+
+Use these endpoints (no generic `/command`):
+
+- `POST /v1/eink/enable`
+- `POST /v1/eink/disable`
+- `POST /v1/eink/refresh`
+- `POST /v1/eink/mode/dynamic`
+- `POST /v1/eink/mode/reading`
+- `GET  /v1/ec/status`
+- `GET  /v1/frontlight`
+- `POST /v1/frontlight/enable` (optional body `{"brightness_level": <int>}`)
+- `POST /v1/frontlight/disable`
+- `POST /v1/frontlight/brightness` (body `{"level": <int>}`)
+
+### Example: set brightness
+
+Request:
+```http
+POST /v1/frontlight/brightness HTTP/1.1
+Content-Type: application/json
+
+{"level":80}
+```
+
+Response:
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"success":true,"readback":"0x50","level":80,"message":"Brightness set to 80"}
+```
+
+### Error behavior
+
+- invalid JSON body: `400`
+- unknown route: `404`
+- wrong method: `405`
+- command-level errors still return current JSON error payload shape
+
+## Access logging requirement (server console)
+
+Every request must log one access line through project logger (not raw stderr default), including:
+- client (`unix-client`)
+- method
+- path
+- status code
+- duration in ms
+
+Example:
+```text
+HTTP unix-client "POST /v1/frontlight/brightness" 200 3.8ms
+```
+
+## Keep unchanged
+
+- Socket path (`/run/tinta4plus.sock`)
 - systemd socket activation (FD 3)
-- command payload shape: `{ "command": "...", "params": {...} }`
-- response JSON keys (`success`, `error`, command-specific fields)
+- business logic in `handle_command()` (transport wrapper maps endpoint -> existing command)
+- response JSON keys (`success`, `error`, plus command-specific fields)
 
 ---
 
-## Step 0 (done): Baseline tests for current protocol
+## Step 0 (done): Baseline tests for old protocol
 
 **File:** `tests/test_unix_socket_protocol.py`
-
-Covers:
-- client sends length-prefixed JSON
-- daemon sends length-prefixed JSON
-- daemon handles one full request/response command roundtrip
 
 Run:
 ```bash
@@ -28,15 +78,15 @@ uv run -m unittest tests/test_unix_socket_protocol.py
 
 ---
 
-## Step 1: Add failing HTTP client tests (RED)
+## Step 1 (RED): Add failing HTTP client endpoint tests
 
 **Create:** `tests/test_http_unix_socket_protocol.py`
 
-Test expectations:
-- client sends `POST /command`
-- `Content-Type: application/json`
-- body `{command, params}`
-- parses JSON response
+Test exactly:
+1. client calls endpoint-specific paths (e.g. `POST /v1/eink/refresh`)
+2. expected JSON body for parameterized routes (e.g. brightness)
+3. parses JSON response
+4. maps transport/HTTP failures to `RuntimeError`
 
 Run (should fail before client refactor):
 ```bash
@@ -45,13 +95,13 @@ uv run -m unittest tests/test_http_unix_socket_protocol.py -v
 
 ---
 
-## Step 2: Refactor client transport (GREEN)
+## Step 2 (GREEN): Refactor client transport + route mapping
 
 **Modify:** `HelperClient.py`
 
-- replace struct framing with HTTP-over-unix-socket connection
-- keep `send_command(command, **params)` API stable
-- map HTTP/socket errors to current `RuntimeError` pattern
+- replace struct framing with HTTP-over-unix-socket
+- add map from current `send_command("...")` values to v1 routes/methods/body
+- keep public API stable: `send_command(command, **params)`
 
 Run:
 ```bash
@@ -60,15 +110,16 @@ uv run -m unittest tests/test_http_unix_socket_protocol.py -v
 
 ---
 
-## Step 3: Add failing HTTP daemon tests (RED)
+## Step 3 (RED): Add failing daemon endpoint + access-log tests
 
 **Create:** `tests/test_helper_daemon_http.py`
 
-Test expectations:
-- accepts `POST /command`
-- returns JSON response
-- invalid JSON => HTTP 400 + `{success:false,error:...}`
-- unknown route => HTTP 404
+Test exactly:
+1. each v1 route maps to expected command behavior
+2. invalid JSON -> 400
+3. unknown route -> 404
+4. wrong method -> 405
+5. access log emitted with method/path/status/duration
 
 Run (should fail before daemon refactor):
 ```bash
@@ -77,13 +128,13 @@ uv run -m unittest tests/test_helper_daemon_http.py -v
 
 ---
 
-## Step 4: Refactor daemon transport (GREEN)
+## Step 4 (GREEN): Refactor daemon transport + endpoint router
 
 **Modify:** `HelperDaemon.py`
 
-- keep `handle_command()` unchanged
-- replace manual recv/send framing with HTTP request handler
-- serve over systemd FD 3 Unix socket
+- replace manual recv/send loop with HTTP handler over FD 3
+- endpoint router maps v1 route+method to existing command dispatcher
+- implement custom access logging to existing logger
 
 Run:
 ```bash
@@ -92,27 +143,19 @@ uv run -m unittest tests/test_helper_daemon_http.py -v
 
 ---
 
-## Step 5: Final regression + docs
+## Step 5: Full regression + docs
 
-**Modify:** `README.md` (helper protocol section)
+**Modify:** `README.md`
+
+- document v1 endpoint table
+- include one request/response example
+- note access log format
 
 Run all tests:
 ```bash
 uv run -m unittest
 ```
 
-Sanity check commands still work:
-- `enable-eink`, `disable-eink`, `refresh-eink`
-- `set-dynamic`, `set-reading`
-- `get-ec-status`, `get-frontlight-state`
-- `enable-frontlight`, `disable-frontlight`, `set-brightness`
-
----
-
-## Commit plan for now
-
-Commit only baseline tests + TL;DR plan:
-```bash
-git add tests/test_unix_socket_protocol.py docs/plans/2026-03-05-http-over-unix-socket-migration.md
-git commit -m "test(protocol): add unix-socket baseline tests and migration plan"
-```
+Sanity commands (via existing UI/CLI):
+- eink: enable/disable/refresh/mode
+- EC/frontlight: status/state/enable/disable/brightness

--- a/docs/plans/2026-03-05-http-over-unix-socket-migration.md
+++ b/docs/plans/2026-03-05-http-over-unix-socket-migration.md
@@ -1,0 +1,118 @@
+# HTTP over Unix Socket Migration (TL;DR)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** switch helper protocol from custom length-prefix JSON to HTTP, on the same Unix socket (`/run/tinta4plus.sock`).
+
+**Keep unchanged:**
+- Socket path
+- systemd socket activation (FD 3)
+- command payload shape: `{ "command": "...", "params": {...} }`
+- response JSON keys (`success`, `error`, command-specific fields)
+
+---
+
+## Step 0 (done): Baseline tests for current protocol
+
+**File:** `tests/test_unix_socket_protocol.py`
+
+Covers:
+- client sends length-prefixed JSON
+- daemon sends length-prefixed JSON
+- daemon handles one full request/response command roundtrip
+
+Run:
+```bash
+uv run -m unittest tests/test_unix_socket_protocol.py
+```
+
+---
+
+## Step 1: Add failing HTTP client tests (RED)
+
+**Create:** `tests/test_http_unix_socket_protocol.py`
+
+Test expectations:
+- client sends `POST /command`
+- `Content-Type: application/json`
+- body `{command, params}`
+- parses JSON response
+
+Run (should fail before client refactor):
+```bash
+uv run -m unittest tests/test_http_unix_socket_protocol.py -v
+```
+
+---
+
+## Step 2: Refactor client transport (GREEN)
+
+**Modify:** `HelperClient.py`
+
+- replace struct framing with HTTP-over-unix-socket connection
+- keep `send_command(command, **params)` API stable
+- map HTTP/socket errors to current `RuntimeError` pattern
+
+Run:
+```bash
+uv run -m unittest tests/test_http_unix_socket_protocol.py -v
+```
+
+---
+
+## Step 3: Add failing HTTP daemon tests (RED)
+
+**Create:** `tests/test_helper_daemon_http.py`
+
+Test expectations:
+- accepts `POST /command`
+- returns JSON response
+- invalid JSON => HTTP 400 + `{success:false,error:...}`
+- unknown route => HTTP 404
+
+Run (should fail before daemon refactor):
+```bash
+uv run -m unittest tests/test_helper_daemon_http.py -v
+```
+
+---
+
+## Step 4: Refactor daemon transport (GREEN)
+
+**Modify:** `HelperDaemon.py`
+
+- keep `handle_command()` unchanged
+- replace manual recv/send framing with HTTP request handler
+- serve over systemd FD 3 Unix socket
+
+Run:
+```bash
+uv run -m unittest tests/test_helper_daemon_http.py -v
+```
+
+---
+
+## Step 5: Final regression + docs
+
+**Modify:** `README.md` (helper protocol section)
+
+Run all tests:
+```bash
+uv run -m unittest
+```
+
+Sanity check commands still work:
+- `enable-eink`, `disable-eink`, `refresh-eink`
+- `set-dynamic`, `set-reading`
+- `get-ec-status`, `get-frontlight-state`
+- `enable-frontlight`, `disable-frontlight`, `set-brightness`
+
+---
+
+## Commit plan for now
+
+Commit only baseline tests + TL;DR plan:
+```bash
+git add tests/test_unix_socket_protocol.py docs/plans/2026-03-05-http-over-unix-socket-migration.md
+git commit -m "test(protocol): add unix-socket baseline tests and migration plan"
+```

--- a/docs/plans/2026-03-15-touch-input-toggle-on-display-switch.md
+++ b/docs/plans/2026-03-15-touch-input-toggle-on-display-switch.md
@@ -1,0 +1,38 @@
+# Touch Input Toggle on Display Switch (TL;DR Plan)
+
+Goal: make touch/pen device toggling happen in the shared switch path so GUI and CLI behave the same.
+
+## Scope
+- Modify only: `mode_switch.py`
+
+## Plan
+1. Add small `xinput` helpers:
+   - list devices from `xinput --list --short`
+   - match IDs by name patterns
+   - enable/disable IDs
+
+2. Use device name groups:
+   - E-Ink input group: `ITE Tech. Inc. ITE T-CON*`
+   - OLED input group: `Wacom HID 537D*`
+
+3. Add `_apply_input_mode(target)`:
+   - `target="eink"`: enable E-Ink IDs, disable OLED IDs
+   - `target="oled"`: enable OLED IDs, disable E-Ink IDs
+
+4. Hook into shared switch path:
+   - in `switch_to_eink(...)` call `_apply_input_mode("eink")`
+   - in `switch_to_oled(...)` call `_apply_input_mode("oled")`
+
+5. Failure policy:
+   - input toggling errors are warning-only
+   - do not fail display switching if `xinput` step fails
+
+6. Manual verification:
+   - run `./toggle-eink.py` in both directions
+   - check monitor: `xrandr --listmonitors`
+   - check input states:
+     - `xinput list-props <id> | grep "Device Enabled"`
+
+## Expected result
+- On E-Ink mode: ITE devices enabled, Wacom devices disabled.
+- On OLED mode: Wacom devices enabled, ITE devices disabled.

--- a/docs/plans/2026-04-03-common-touch-mapping-on-display-switch.md
+++ b/docs/plans/2026-04-03-common-touch-mapping-on-display-switch.md
@@ -1,0 +1,151 @@
+# Common Touch Mapping on Display Switch Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the shared OLED↔E-Ink switch path manage both input enablement and X11 output mapping so touch/stylus devices work consistently in GUI and CLI.
+
+**Architecture:** Extend `mode_switch.py`'s existing XInput helpers so `_apply_input_mode(...)` both enables/disables device groups and maps the enabled group to the active output with `xinput map-to-output`. Keep failures warning-only so display switching remains resilient. Cover the change with focused unit tests around helper behavior and preserve the existing shared switch flow used by both `Tinta4Plus.py` and `toggle-eink.py`.
+
+**Tech Stack:** Python 3, X11/Xorg, `xinput`, `xrandr`, `unittest`/`unittest.mock`
+
+**Execution Requirement (commit-as-you-go):** Each completed task must be committed before starting the next task. Do not batch multiple tasks into one commit.
+
+---
+
+## Design Summary
+
+- [ ] Keep the common-path ownership in `mode_switch.py`; do not duplicate input logic in GUI or CLI callers.
+- [ ] Continue matching device families by name pattern:
+  - E-Ink devices: `ITE Tech. Inc. ITE T-CON*`
+  - OLED devices: `Wacom HID 537D*`
+- [ ] For `target="eink"`:
+  - enable all matching ITE devices
+  - disable all matching Wacom devices not shared with ITE
+  - map enabled ITE devices to `eDP-2`
+- [ ] For `target="oled"`:
+  - enable all matching Wacom devices
+  - disable all matching ITE devices not shared with Wacom
+  - map enabled Wacom devices to `eDP-1`
+- [ ] Treat input failures as warning-only; do not abort successful display mode changes because `xinput` mapping failed.
+- [ ] Prefer `xinput map-to-output` over hand-written CTM math in this change.
+- [ ] Map all matching subdevices, not just the primary touch device, so pen/touch/eraser remain consistent.
+
+## Files
+
+- [ ] Modify: `mode_switch.py`
+- [ ] Create or modify tests: `tests/test_mode_switch_input_mode.py`
+- [ ] Optionally update docs after verification: `README.md` (known-bug wording only if warranted by verified behavior)
+
+## Task 1: Add failing tests for common-path input mapping
+
+**Files:**
+- [ ] Test: `tests/test_mode_switch_input_mode.py`
+
+### Checklist
+- [ ] Add a focused test module for `mode_switch.py` input helpers.
+- [ ] Add a failing test proving `_apply_input_mode(logger, "eink")`:
+  - [ ] lists devices
+  - [ ] enables matching ITE IDs
+  - [ ] disables matching Wacom IDs
+  - [ ] maps enabled ITE IDs to `eDP-2`
+- [ ] Add a failing test proving `_apply_input_mode(logger, "oled")` maps enabled Wacom IDs to `eDP-1`.
+- [ ] Add a failing test proving mapping failures make `_apply_input_mode(...)` return `False` without raising.
+- [ ] Add a failing test proving no devices found returns `False` and logs/skips cleanly.
+- [ ] Use mocking around `_list_xinput_devices`, `_set_input_enabled`, and the new mapping helper so tests stay deterministic.
+- [ ] Run only the new test file to confirm it fails for the expected missing behavior.
+
+### Suggested test command
+- [ ] Run: `python -m unittest tests.test_mode_switch_input_mode -v`
+
+## Task 2: Add XInput output-mapping helper(s)
+
+**Files:**
+- [ ] Modify: `mode_switch.py`
+
+### Checklist
+- [ ] Add a small helper such as `_map_input_to_output(logger, device_id, output_name)`.
+- [ ] Implement it via `_run_xinput(logger, ["map-to-output", str(device_id), output_name])`.
+- [ ] Return boolean success/failure rather than raising.
+- [ ] Keep helper naming/style aligned with `_set_input_enabled(...)`.
+- [ ] Do not add custom matrix math in this task.
+
+## Task 3: Extend `_apply_input_mode(...)` to map enabled devices
+
+**Files:**
+- [ ] Modify: `mode_switch.py`
+
+### Checklist
+- [ ] Define output selection inside `_apply_input_mode(...)`:
+  - [ ] `target="eink"` → output `DISPLAY_EINK`
+  - [ ] `target="oled"` → output `DISPLAY_OLED`
+- [ ] Keep the current device-group selection logic intact.
+- [ ] After enabling target IDs, map each enabled target ID to the target output.
+- [ ] Preserve current disable behavior for the non-target group.
+- [ ] Aggregate failures across enable/disable/map steps into a final boolean result.
+- [ ] Continue warning on unknown target and return `False`.
+- [ ] Ensure an empty device list still logs/skips and returns `False`.
+- [ ] Avoid changing `switch_to_eink(...)` / `switch_to_oled(...)` call sites beyond relying on the enhanced helper.
+
+## Task 4: Verify unit tests pass
+
+**Files:**
+- [ ] Test: `tests/test_mode_switch_input_mode.py`
+- [ ] Verify no unrelated tests need changes unless they assert helper internals
+
+### Checklist
+- [ ] Run the new test file until it passes.
+- [ ] Run existing mode-switch related tests to guard against regressions.
+
+### Suggested test commands
+- [ ] Run: `python -m unittest tests.test_mode_switch_input_mode -v`
+- [ ] Run: `python -m unittest tests.test_mode_switch_state -v`
+
+## Task 5: Manual verification on real X11 hardware
+
+**Files:**
+- [ ] Verify runtime behavior only; no code changes unless a new issue is discovered
+
+### Checklist
+- [ ] Switch to E-Ink using the shared path: `./toggle-eink.py`
+- [ ] Confirm monitor state: `xrandr --listmonitors`
+- [ ] Confirm ITE devices are enabled:
+  - [ ] `xinput list-props 13 | grep "Device Enabled"`
+  - [ ] Repeat for other matching ITE IDs present on the machine
+- [ ] Confirm enabled ITE device CTM is no longer identity after mapping:
+  - [ ] `xinput list-props 13 | grep "Coordinate Transformation Matrix"`
+- [ ] Test actual tapping on E-Ink.
+- [ ] Switch back to OLED using the same shared path: `./toggle-eink.py`
+- [ ] Confirm Wacom devices are enabled and mapped to `eDP-1`.
+- [ ] Confirm ITE devices are disabled in OLED mode.
+- [ ] Record any residual issue separately if taps still register with wrong coordinates even after `map-to-output`.
+
+## Task 6: Optional documentation update
+
+**Files:**
+- [ ] Modify: `README.md` only if manual verification shows the known-bug statement is no longer accurate
+
+### Checklist
+- [ ] If touch mapping in scaled E-Ink mode is improved but not fully solved, keep the known-bug note and narrow its wording.
+- [ ] If touch mapping is verified fixed in the tested setup, update the known-bug section accordingly.
+- [ ] Do not claim universal hardware support; scope statements to the tested environment.
+
+## Task 7: Final verification before completion
+
+### Checklist
+- [ ] Run all verification commands again before claiming success.
+- [ ] Capture exact outputs for the passing tests and the XInput state checks.
+- [ ] Confirm no GUI/CLI-specific code path duplicates input mapping logic.
+- [ ] Review diff for `mode_switch.py` and the new test file only.
+
+### Suggested verification commands
+- [ ] `python -m unittest tests.test_mode_switch_input_mode tests.test_mode_switch_state -v`
+- [ ] `git diff -- mode_switch.py tests/test_mode_switch_input_mode.py README.md`
+- [ ] `xrandr --listmonitors`
+- [ ] `xinput --list --short`
+
+## Commit plan (required)
+
+- [ ] Commit 1 (after Task 1): failing/passing tests for input mapping helper behavior
+- [ ] Commit 2 (after Tasks 2-3): common-path input output-mapping implementation
+- [ ] Commit 3 (after Tasks 4-7): verification and docs update only if verification warrants it
+- [ ] Before opening/merging PR, ensure task order and commit order match (commit-as-you-go evidence).

--- a/docs/plans/2026-04-03-display-state-sync.md
+++ b/docs/plans/2026-04-03-display-state-sync.md
@@ -1,0 +1,187 @@
+# Display State Sync Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make GUI and CLI derive current display mode from shared state detection so startup, reconnect, timers, controls, and exit behavior match the real OLED/E-Ink state.
+
+**Architecture:** Add a shared display-state probe in `mode_switch.py` that reports `oled`, `eink`, `mixed`, or `unknown` based on `DisplayManager.is_display_active(...)`. Update both the CLI and Tk GUI to consume that shared state. Keep presentation logic in `Tinta4Plus.py`, including widget enablement, timers, floating button lifecycle, and frontlight warning/slider state.
+
+**Tech Stack:** Python 3, tkinter, unittest, existing `DisplayManager`, `HelperClient`, and shared `mode_switch.py` utilities.
+
+---
+
+## Rules for execution
+
+- [ ] Follow TDD for every task: write the failing test first, run it, implement the minimum fix, rerun the test.
+- [ ] **Commit after each task before moving to the next one.** Do not batch multiple tasks into one commit.
+- [ ] If a task uncovers unexpected behavior, update this checklist before continuing.
+
+---
+
+## Task 1: Add shared display-state detection
+
+**Files:**
+- Create: `tests/test_mode_switch_state.py`
+- Modify: `mode_switch.py`
+
+### Checklist
+- [ ] Write failing tests in `tests/test_mode_switch_state.py` for:
+  - only `eDP-2` active -> `mode == "eink"`
+  - only `eDP-1` active -> `mode == "oled"`
+  - both active -> `mode == "mixed"`
+  - neither active -> `mode == "unknown"`
+- [ ] Run `python -m unittest tests.test_mode_switch_state -v` and confirm it fails because `get_display_state` does not exist yet.
+- [ ] Implement `get_display_state(display_mgr)` in `mode_switch.py` returning:
+  - `oled_active`
+  - `eink_active`
+  - `mode`
+- [ ] Run `python -m unittest tests.test_mode_switch_state -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add tests/test_mode_switch_state.py mode_switch.py
+  git commit -m "feat: add shared display state detection"
+  ```
+
+---
+
+## Task 2: Switch the CLI to shared display-state detection
+
+**Files:**
+- Modify: `toggle-eink.py`
+- Modify: `tests/test_mode_switch_state.py`
+
+### Checklist
+- [ ] Extend `tests/test_mode_switch_state.py` with a CLI-oriented test proving the CLI uses shared state rather than direct `is_display_active(DISPLAY_EINK)` checks.
+- [ ] Run `python -m unittest tests.test_mode_switch_state -v` and confirm the new test fails.
+- [ ] Update `toggle-eink.py` to import and use `get_display_state` from `mode_switch.py`.
+- [ ] Make the CLI choose `switch_to_oled(...)` when `state["mode"] == "eink"` and `switch_to_eink(...)` otherwise.
+- [ ] Run `python -m unittest tests.test_mode_switch_state -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add toggle-eink.py tests/test_mode_switch_state.py
+  git commit -m "refactor: use shared display state detection in cli"
+  ```
+
+---
+
+## Task 3: Add GUI display-state sync behavior
+
+**Files:**
+- Create: `tests/test_tinta4plus_ui_state.py`
+- Modify: `Tinta4Plus.py`
+
+### Checklist
+- [ ] Write failing GUI sync tests in `tests/test_tinta4plus_ui_state.py` without creating a real Tk window.
+- [ ] Cover at least:
+  - eInk active -> button says enabled, refresh/mode buttons enabled, timer started, floating button ensured
+  - OLED active -> button says disabled, refresh/mode buttons disabled, timer stopped, floating button destroyed
+  - mixed or unknown -> conservative disabled UI with a warning/log
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm it fails because the sync helpers do not exist yet.
+- [ ] Add `_ensure_floating_refresh_button(self)` to `Tinta4Plus.py`.
+- [ ] Add `_destroy_floating_refresh_button(self)` to `Tinta4Plus.py`.
+- [ ] Add `sync_ui_from_display_state(self)` to `Tinta4Plus.py` using shared `get_display_state(...)`.
+- [ ] Keep UI ownership in `Tinta4Plus.py`:
+  - widget text/color
+  - button enable/disable state
+  - periodic refresh timer lifecycle
+  - floating refresh button lifecycle
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat: sync gui widgets from shared display state"
+  ```
+
+---
+
+## Task 4: Sync GUI state on startup, reconnect, and successful toggles
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests proving `initialize_helper()` calls `sync_ui_from_display_state()` after a successful helper connect.
+- [ ] Add failing tests proving `attempt_helper_restart()` calls `sync_ui_from_display_state()` after a successful reconnect.
+- [ ] Add failing tests proving successful `on_eink_toggled()` paths reuse `sync_ui_from_display_state()` instead of manually duplicating widget state changes.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm the lifecycle tests fail.
+- [ ] Update `initialize_helper()` to call `self.sync_ui_from_display_state()` immediately after a successful helper connection.
+- [ ] Update `attempt_helper_restart()` to call `self.sync_ui_from_display_state()` immediately after a successful reconnect.
+- [ ] Update successful toggle paths to use `self.sync_ui_from_display_state()`.
+- [ ] Keep user-facing status messages, but remove duplicated widget-state mutation where the sync method now owns it.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "refactor: sync gui state on connect reconnect and toggle"
+  ```
+
+---
+
+## Task 5: Fix frontlight recovery UI state
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests for `check_ec_status()` covering:
+  - EC available + Secure Boot off -> brightness slider enabled, warning hidden, frontlight state synced
+  - EC unavailable or Secure Boot on -> brightness slider disabled, warning shown
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm it fails in the recovery path.
+- [ ] Update `check_ec_status()` so the success path explicitly:
+  - enables `brightness_scale`
+  - hides the `secure_boot_warning`
+  - calls `sync_frontlight_state()`
+- [ ] Keep the existing disable path for unavailable EC / Secure Boot enabled.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "fix: resync frontlight controls after ec recovery"
+  ```
+
+---
+
+## Task 6: Final verification
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `toggle-eink.py`
+- Verify: `Tinta4Plus.py`
+- Verify: `tests/test_mode_switch_state.py`
+- Verify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Run the focused automated tests:
+  ```bash
+  python -m unittest \
+    tests.test_mode_switch_state \
+    tests.test_tinta4plus_ui_state \
+    tests.test_helper_daemon_http \
+    tests.test_http_unix_socket_protocol \
+    tests.test_unix_socket_protocol -v
+  ```
+- [ ] Confirm all focused tests pass.
+- [ ] Run a quick manual verification:
+  ```bash
+  ./toggle-eink.py
+  python Tinta4Plus.py
+  ```
+- [ ] Manually verify:
+  - start GUI while already on E-Ink -> button shows enabled
+  - refresh/mode buttons enabled when E-Ink is active
+  - floating refresh button appears when E-Ink is active
+  - reconnect resyncs GUI state
+  - frontlight slider recovers when EC access is available
+  - closing app while synced to E-Ink still follows the OLED/privacy-image path
+- [ ] Review the diff:
+  ```bash
+  git status --short
+  git diff -- mode_switch.py toggle-eink.py Tinta4Plus.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py
+  ```
+- [ ] Commit final verification or cleanup if needed:
+  ```bash
+  git add mode_switch.py toggle-eink.py Tinta4Plus.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py
+  git commit -m "test: verify display state sync across gui and cli"
+  ```

--- a/docs/plans/2026-04-03-orientation-toggle-design.md
+++ b/docs/plans/2026-04-03-orientation-toggle-design.md
@@ -1,0 +1,73 @@
+# Orientation Toggle Design
+
+**Goal:** Add a UI control that toggles the active internal display between landscape and portrait, syncs from live `xrandr` state on startup, and keeps later OLED↔E-Ink switches aligned with the last orientation chosen in the app.
+
+## Requirements
+
+- Add a button in the GUI display controls for orientation.
+- Use user-facing labels `Landscape` and `Portrait`.
+- Map the two supported modes to:
+  - `Landscape` -> `xrandr --rotate normal`
+  - `Portrait` -> `xrandr --rotate left`
+- Only one internal output is active at a time; operate on the active output only.
+- On startup, do **not** force rotation. Read current state from `xrandr` and sync the UI to reality.
+- After the user changes orientation in the app, later OLED↔E-Ink switches should apply that last app-selected orientation to the newly active output.
+- Keep failures non-fatal and visible through logging/UI status.
+
+## Recommended Approach
+
+Introduce shared rotation helpers in `DisplayManager.py`, keep mode-switch ownership in `mode_switch.py`, and keep button/state presentation in `Tinta4Plus.py`.
+
+This separates concerns cleanly:
+- `DisplayManager.py` owns `xrandr` querying and rotation commands.
+- `mode_switch.py` owns when rotation is re-applied after shared OLED/E-Ink switching.
+- `Tinta4Plus.py` owns labels, button state, startup sync, and click handling.
+
+## Behavior
+
+### Startup
+- Detect the active display (`eDP-1` or `eDP-2`).
+- Query its current rotation from `xrandr`.
+- Update the GUI button to show `Orientation: Landscape` or `Orientation: Portrait`.
+- Do not change display rotation during startup sync.
+
+### Button press
+- Toggle the target rotation for the active display.
+- Apply rotation via `xrandr --output <display> --rotate <normal|left>`.
+- Re-read `xrandr` to confirm the resulting state.
+- Update the UI only after confirmation.
+- Save the last app-selected orientation so future display switches can reuse it.
+
+### Display switching
+- After `switch_to_eink(...)` or `switch_to_oled(...)` successfully enables the target display, apply the last app-selected orientation if one exists.
+- Re-apply input mapping afterward if needed so touch/stylus stays aligned.
+- If no app-selected orientation has been stored yet, do not impose one.
+
+## Edge Cases
+
+- If no active display is detected, disable the orientation button and log a warning.
+- If `xrandr` rotation fails, leave the UI showing the last confirmed live state.
+- If the user changes rotation outside the app, the next startup sync reflects that live state.
+- Because E-Ink refresh is slower, status text/logging should make rotation activity explicit.
+
+## Files
+
+- Modify: `DisplayManager.py`
+- Modify: `mode_switch.py`
+- Modify: `Tinta4Plus.py`
+- Modify: `toggle-eink.py` only if settings loading or shared helpers need a small extension
+- Add/modify tests in:
+  - `tests/test_display_manager_rotation.py`
+  - `tests/test_mode_switch_rotation.py`
+  - `tests/test_tinta4plus_ui_state.py`
+
+## Testing
+
+- Unit-test `xrandr` parsing and rotation command generation.
+- Unit-test shared mode-switch rotation re-application behavior.
+- Unit-test GUI startup sync and button toggle behavior without creating a real Tk window.
+- Manually verify on hardware:
+  - startup sync reflects current `xrandr` orientation
+  - button toggles active display between landscape/portrait
+  - switching OLED↔E-Ink preserves the last app-selected orientation
+  - touch/input remains mapped correctly after rotation

--- a/docs/plans/2026-04-03-orientation-toggle-implementation.md
+++ b/docs/plans/2026-04-03-orientation-toggle-implementation.md
@@ -1,0 +1,197 @@
+# Orientation Toggle Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a GUI orientation button that shows live landscape/portrait state from `xrandr`, rotates the active internal display on demand, and re-applies the last app-selected orientation after OLED↔E-Ink switches.
+
+**Architecture:** Add shared rotation query/apply helpers to `DisplayManager.py`, keep rotation re-application in the shared switch path in `mode_switch.py`, and keep UI labels/state in `Tinta4Plus.py`. Startup must sync from live `xrandr` without forcing changes; only post-click and post-switch flows should enforce the app-selected orientation.
+
+**Tech Stack:** Python 3, tkinter, X11/Xorg, `xrandr`, existing `DisplayManager`, shared `mode_switch.py`, `unittest`/`unittest.mock`.
+
+**Execution Requirement (commit-as-you-go):** Each completed task must be committed before starting the next task. Do not batch multiple tasks into one commit.
+
+---
+
+## Rules for execution
+
+- [ ] Follow TDD for every task: write the failing test first, run it, implement the minimum fix, rerun the test.
+- [ ] **Commit after each task before moving to the next one.**
+- [ ] Keep the UX labels as `Landscape` and `Portrait`, but store raw `xrandr` values where helpful.
+- [ ] Startup sync must read live `xrandr` state and must not force a rotation change.
+- [ ] If a task uncovers unexpected behavior, update this checklist before continuing.
+
+---
+
+## Task 1: Add shared display rotation helpers
+
+**Files:**
+- [ ] Modify: `DisplayManager.py`
+- [ ] Create: `tests/test_display_manager_rotation.py`
+
+### Checklist
+- [ ] Add failing tests for `DisplayManager` helpers that:
+  - [ ] detect the currently active display from mocked `xrandr --query` output
+  - [ ] parse active rotation for `eDP-1` / `eDP-2`
+  - [ ] treat `normal` as landscape and `left` as portrait
+  - [ ] reject or safely ignore unsupported rotations like `right` / `inverted`
+- [ ] Add a failing test proving `set_display_rotation(display_name, rotation)` builds `xrandr --output <display> --rotate <rotation>`.
+- [ ] Run: `python -m unittest tests.test_display_manager_rotation -v` and confirm it fails.
+- [ ] Implement minimal helpers in `DisplayManager.py`, such as:
+  - [ ] `get_active_display()`
+  - [ ] `get_display_rotation(display_name)`
+  - [ ] `set_display_rotation(display_name, rotation)`
+- [ ] Invalidate the `xrandr` cache after successful rotation changes.
+- [ ] Run: `python -m unittest tests.test_display_manager_rotation -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py
+  git commit -m "feat(display): add rotation query and apply helpers"
+  ```
+
+---
+
+## Task 2: Add shared orientation preference handling in mode switch logic
+
+**Files:**
+- [ ] Modify: `mode_switch.py`
+- [ ] Create: `tests/test_mode_switch_rotation.py`
+
+### Checklist
+- [ ] Add failing tests for shared rotation helpers in `mode_switch.py` that:
+  - [ ] load/save the last app-selected orientation preference
+  - [ ] do nothing if no preference exists yet
+  - [ ] apply the stored rotation to the active display after a successful switch
+  - [ ] leave switching successful even if rotation application fails
+- [ ] Run: `python -m unittest tests.test_mode_switch_rotation -v` and confirm it fails.
+- [ ] Add minimal shared helpers in `mode_switch.py` for orientation preference persistence.
+- [ ] Store only supported values: `normal` and `left`.
+- [ ] After successful `switch_to_eink(...)`, apply stored orientation to the newly active output if present.
+- [ ] After successful `switch_to_oled(...)`, apply stored orientation to the newly active output if present.
+- [ ] Treat touch remapping after rotation as required, not optional.
+- [ ] If rotation is applied after a switch, re-run `_apply_input_mode(...)` for the active target so touch mapping stays aligned.
+- [ ] If a user-triggered rotation succeeds from the GUI, re-run `_apply_input_mode(...)` for the current target immediately after confirming the new rotation.
+- [ ] Reuse existing `xinput map-to-output` behavior; do not add custom CTM rotation math unless hardware verification proves it is necessary.
+- [ ] Keep touch-remap failures warning-only so successful display switching or rotation still returns success.
+- [ ] Keep rotation failures warning-only so successful display switching still returns success.
+- [ ] Run: `python -m unittest tests.test_mode_switch_rotation -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add mode_switch.py tests/test_mode_switch_rotation.py
+  git commit -m "feat(mode-switch): preserve app-selected orientation across display switches"
+  ```
+
+---
+
+## Task 3: Add GUI startup sync and orientation button behavior
+
+**Files:**
+- [ ] Modify: `Tinta4Plus.py`
+- [ ] Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing GUI tests without creating a real Tk window for:
+  - [ ] startup sync reads live `xrandr` orientation and updates the button label
+  - [ ] no active display disables the orientation button
+  - [ ] clicking the button toggles between `Landscape` and `Portrait`
+  - [ ] a successful GUI rotation re-runs shared input mapping for the current mode
+  - [ ] UI updates only after confirmed rotation state is re-read
+  - [ ] failed rotation leaves the previous confirmed label intact
+- [ ] Run: `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm the new tests fail.
+- [ ] Add a new orientation button in the `Display Control` section of `Tinta4Plus.py`.
+- [ ] Use labels:
+  - [ ] `Orientation: Landscape`
+  - [ ] `Orientation: Portrait`
+- [ ] Add GUI helpers such as:
+  - [ ] `sync_orientation_from_display_state()`
+  - [ ] `on_orientation_toggled()`
+- [ ] On startup/helper reconnect, call the orientation sync helper after display state sync.
+- [ ] On successful button press:
+  - [ ] rotate the active display
+  - [ ] confirm the new live rotation
+  - [ ] re-run shared input mapping for the current mode so touch stays aligned
+  - [ ] save the orientation preference through shared logic
+  - [ ] refresh the UI label/status/logging
+- [ ] On failure, show/log an error and keep the last confirmed UI state.
+- [ ] Run: `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm it passes.
+- [ ] Commit progress:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat(ui): add orientation toggle with startup xrandr sync"
+  ```
+
+---
+
+## Task 4: Ensure CLI/shared switch path honors orientation behavior
+
+**Files:**
+- [ ] Modify: `toggle-eink.py` only if needed
+- [ ] Modify: `tests/test_mode_switch_rotation.py`
+
+### Checklist
+- [ ] Add a regression test proving the shared OLED↔E-Ink path applies stored orientation regardless of whether the switch is triggered from GUI or CLI.
+- [ ] Confirm `toggle-eink.py` does not need duplicate rotation logic if shared mode-switch code already covers it.
+- [ ] If settings loading needs a small extension, keep it minimal and shared.
+- [ ] Run:
+  - [ ] `python -m unittest tests.test_mode_switch_rotation -v`
+  - [ ] `python -m unittest tests.test_mode_switch_state -v`
+- [ ] Commit progress:
+  ```bash
+  git add toggle-eink.py mode_switch.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py
+  git commit -m "test(cli): verify shared switch path honors orientation preference"
+  ```
+
+---
+
+## Task 5: Focused verification
+
+**Files:**
+- [ ] Verify: `DisplayManager.py`
+- [ ] Verify: `mode_switch.py`
+- [ ] Verify: `Tinta4Plus.py`
+- [ ] Verify: `tests/test_display_manager_rotation.py`
+- [ ] Verify: `tests/test_mode_switch_rotation.py`
+- [ ] Verify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Run the focused automated tests:
+  ```bash
+  python -m unittest \
+    tests.test_display_manager_rotation \
+    tests.test_mode_switch_rotation \
+    tests.test_mode_switch_state \
+    tests.test_tinta4plus_ui_state -v
+  ```
+- [ ] Confirm all focused tests pass.
+- [ ] Run a manual verification on hardware:
+  ```bash
+  xrandr --query
+  python Tinta4Plus.py
+  ./toggle-eink.py
+  xrandr --query
+  ```
+- [ ] Manually verify:
+  - [ ] startup button matches current live orientation
+  - [ ] button toggles active display between landscape and portrait
+  - [ ] switching OLED↔E-Ink preserves the last app-selected orientation
+  - [ ] touch/input is remapped after every successful rotation
+  - [ ] touch/input remains correctly mapped after rotation
+  - [ ] failures, if any, leave the UI showing the last confirmed state
+- [ ] Review the diff:
+  ```bash
+  git diff -- DisplayManager.py mode_switch.py Tinta4Plus.py toggle-eink.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py
+  ```
+- [ ] Commit final verification or cleanup if needed:
+  ```bash
+  git add DisplayManager.py mode_switch.py Tinta4Plus.py toggle-eink.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py
+  git commit -m "test: verify orientation toggle behavior"
+  ```
+
+---
+
+## Commit plan (required)
+
+- [ ] Commit 1: shared display rotation query/apply helpers
+- [ ] Commit 2: mode-switch orientation preference persistence and re-apply logic
+- [ ] Commit 3: GUI orientation button and startup sync behavior
+- [ ] Commit 4: shared-path CLI regression coverage
+- [ ] Commit 5: verification/cleanup only if needed

--- a/docs/plans/2026-04-04-lid-close-eink-rotation-sync.md
+++ b/docs/plans/2026-04-04-lid-close-eink-rotation-sync.md
@@ -1,0 +1,216 @@
+# Lid-Close E-Ink Rotation Sync Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the GUI stay synchronized with out-of-band display changes, hold a lid-close suspend inhibitor while E-Ink is active, and rotate E-Ink to portrait on lid close and back to landscape on lid open with touch remap/recovery after each rotation.
+
+**Architecture:** Keep `Tinta4Plus.py` as the sole policy owner and UI owner. Add one small Python helper process that blocks on lid and RandR/display-change events and sends only invalidation notifications to the parent over a single IPC channel. The parent re-reads live lid/display state on every event and runs one Tk-thread reconciliation method that decides whether E-Ink is active, whether the inhibitor must run, and whether to rotate/remap/recover touch.
+
+**Tech Stack:** Python 3, tkinter, multiprocessing (`Process`, `Pipe`), X11 RandR notifications, D-Bus login1 lid notifications, `systemd-inhibit`, existing `DisplayManager.py` / `mode_switch.py` rotation and touch helpers, unittest.
+
+---
+
+## Rules for execution
+
+- [ ] Follow TDD for every task: write the failing test first, run it, implement the minimum fix, rerun the test.
+- [ ] **Commit after each task before moving to the next one.**
+- [ ] `Tinta4Plus.py` remains the only owner of policy and side effects.
+- [ ] The helper process emits invalidations only; it must not decide lid policy, display mode, rotation, input remap, or inhibitor behavior.
+- [ ] All GUI mutation stays on the Tk thread.
+- [ ] On every helper event, the parent must treat live system state as the source of truth.
+
+---
+
+## Task 1: Add one GUI reconciler for live lid/display state
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests for a small GUI-owned state model tracking:
+  - display mode
+  - lid state
+  - inhibitor running/not running
+  - last applied E-Ink orientation
+- [ ] Add a failing test for one parent-owned method such as `_reconcile_from_live_state()`.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm failure.
+- [ ] Implement the minimal GUI-owned sync state and reconciler entry point in `Tinta4Plus.py`.
+- [ ] Ensure the reconciler reads live display state and live lid state itself.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm pass.
+- [ ] Commit:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat: add gui reconciler for lid and display state"
+  ```
+
+---
+
+## Task 2: Add one helper process for lid and RandR invalidations
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Create: `event_watcher.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests proving one helper process is started and stopped cleanly.
+- [ ] Add a failing test proving one IPC channel is used.
+- [ ] Add failing tests for helper notifications:
+  - `("lid", None)`
+  - `("randr", None)`
+  - `("error", "...")`
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm failure.
+- [ ] Implement `event_watcher.py` as one helper process watching both lid and RandR events.
+- [ ] Use one `multiprocessing.Pipe` between GUI and helper.
+- [ ] Keep helper output limited to invalidations only.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm pass.
+- [ ] Commit:
+  ```bash
+  git add Tinta4Plus.py event_watcher.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat: add single helper for lid and randr invalidations"
+  ```
+
+---
+
+## Task 3: Connect helper notifications to Tk-thread reconciliation
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests proving helper notifications trigger reconciliation on the Tk thread.
+- [ ] Add a failing test proving the notification path does not perform direct side effects.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm failure.
+- [ ] Implement the minimal parent receive path for helper notifications.
+- [ ] Ensure helper notifications only schedule or trigger `_reconcile_from_live_state()`.
+- [ ] Log helper errors without crashing the GUI.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm pass.
+- [ ] Commit:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat: trigger reconciliation from helper events"
+  ```
+
+---
+
+## Task 4: Add inhibitor lifecycle in the reconciler
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests proving the reconciler starts `systemd-inhibit` when display mode becomes `eink`.
+- [ ] Add failing tests proving the reconciler stops it when display mode is not `eink`.
+- [ ] Add a failing test proving duplicate events do not create duplicate inhibitors.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm failure.
+- [ ] Implement minimal inhibitor lifecycle helpers in `Tinta4Plus.py`.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm pass.
+- [ ] Commit:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat: hold lid-close inhibitor while eink is active"
+  ```
+
+---
+
+## Task 5: Add lid-driven E-Ink rotation and touch recovery
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+- Verify: `mode_switch.py`
+
+### Checklist
+- [ ] Add failing tests proving:
+  - `eink + lid closed -> portrait`
+  - `eink + lid open -> landscape`
+  - `not eink -> no lid-driven orientation action`
+- [ ] Add failing tests proving orientation changes apply the correct rotation, reapply E-Ink input mode, and call `ensure_touch_available(self.logger, "eink")`.
+- [ ] Add a failing test proving duplicate invalidations with no effective change are ignored.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm failure.
+- [ ] Implement minimal desired-orientation logic and action path in the reconciler.
+- [ ] Keep the reconciler idempotent.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm pass.
+- [ ] Commit:
+  ```bash
+  git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+  git commit -m "feat: rotate and recover touch from lid-driven eink state"
+  ```
+
+---
+
+## Task 6: Handle out-of-band display changes and shutdown cleanup
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `event_watcher.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+### Checklist
+- [ ] Add failing tests proving a `randr` invalidation causes GUI resync from live state.
+- [ ] Add failing tests proving app shutdown stops helper handling, stops the helper process, and stops the inhibitor.
+- [ ] Add a failing test proving helper `error` notifications are logged and do not crash the GUI.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm failure.
+- [ ] Implement minimal resync and cleanup behavior.
+- [ ] Do not add restart machinery unless required by observed failures.
+- [ ] Run `python -m unittest tests.test_tinta4plus_ui_state -v` and confirm pass.
+- [ ] Commit:
+  ```bash
+  git add Tinta4Plus.py event_watcher.py tests/test_tinta4plus_ui_state.py
+  git commit -m "fix: resync gui and clean up helper lifecycle"
+  ```
+
+---
+
+## Task 7: Final verification
+
+**Files:**
+- Verify: `Tinta4Plus.py`
+- Verify: `event_watcher.py`
+- Verify: `mode_switch.py`
+- Verify: `DisplayManager.py`
+- Verify: `tests/test_tinta4plus_ui_state.py`
+- Verify: `tests/test_mode_switch_rotation.py`
+- Verify: `tests/test_mode_switch_input_mode.py`
+
+### Checklist
+- [ ] Run focused automated tests:
+  ```bash
+  python -m unittest \
+    tests.test_tinta4plus_ui_state \
+    tests.test_mode_switch_rotation \
+    tests.test_mode_switch_input_mode -v
+  ```
+- [ ] Run the broader suite:
+  ```bash
+  python -m unittest discover -s tests -v
+  ```
+- [ ] Run manual hardware verification:
+  ```bash
+  python Tinta4Plus.py
+  ```
+- [ ] Manually verify:
+  - switching to E-Ink starts the inhibitor
+  - switching away from E-Ink stops the inhibitor
+  - out-of-band display changes resync the GUI
+  - lid close while E-Ink is active rotates to portrait
+  - lid open while E-Ink is active rotates back to landscape
+  - touch remains usable after both lid-driven rotations
+  - lid events while OLED is active do not force E-Ink behavior
+- [ ] Inspect inhibitors:
+  ```bash
+  systemd-inhibit --list
+  ```
+- [ ] Inspect the diff:
+  ```bash
+  git status --short
+  git diff -- Tinta4Plus.py event_watcher.py mode_switch.py DisplayManager.py tests/test_tinta4plus_ui_state.py tests/test_mode_switch_rotation.py tests/test_mode_switch_input_mode.py
+  ```
+- [ ] Commit final cleanup if needed:
+  ```bash
+  git add Tinta4Plus.py event_watcher.py mode_switch.py DisplayManager.py tests/test_tinta4plus_ui_state.py tests/test_mode_switch_rotation.py tests/test_mode_switch_input_mode.py
+  git commit -m "feat: sync eink lid rotation with helper-driven lid and randr events"
+  ```

--- a/docs/plans/2026-04-04-lower-scale-reset-on-target-display.md
+++ b/docs/plans/2026-04-04-lower-scale-reset-on-target-display.md
@@ -1,0 +1,142 @@
+# Lower Scale Reset on Target Display Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make display enabling automatically apply an intermediate scale of `1.0` on the target display before applying a lower requested scale, preventing X/XFCE clipping when switching from a larger scale to a smaller one.
+
+**Architecture:** Keep the fix centralized in `DisplayManager.enable_display()` so both GUI and CLI mode switches inherit the workaround automatically. Add one helper that can read a display's current effective scale from live `xrandr` state, plus one helper that builds/applies a single scale configuration for a target output. `enable_display()` should compare the target output's current effective scale with the requested scale and only do the two-step `1.0 -> target` flow when the requested scale is lower.
+
+**Tech Stack:** Python 3, X11/XRandR (`xrandr`), existing `DisplayManager`, `unittest` / `unittest.mock`
+
+---
+
+## Task 1: Add failing tests for lower-scale reset behavior
+
+**Files:**
+- Modify: `tests/test_display_manager_rotation.py`
+- Verify: `DisplayManager.py`
+
+- [ ] Add a failing test proving lowering scale on the target display triggers two applies on that same target output.
+  - Example scenario: current effective scale `1.9`, requested scale `1.5`, target display `eDP-1`
+  - Expect first xrandr apply to target `eDP-1` at `1.0`
+  - Expect second xrandr apply to target `eDP-1` at `1.5`
+- [ ] Add a failing test proving increasing scale still applies only once.
+  - Example scenario: current effective scale `1.5`, requested scale `1.9`
+  - Expect one xrandr apply only
+- [ ] Add a failing test proving unknown current scale falls back to direct apply.
+  - Example scenario: current scale cannot be parsed
+  - Expect one xrandr apply only
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm the tests fail for the expected reason: missing lower-scale reset orchestration in `DisplayManager`.
+
+---
+
+## Task 2: Add scale parsing and one-shot apply helpers in `DisplayManager`
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Add `get_effective_display_scale(self, display_name)`.
+  - Read live `xrandr` output via `_get_xrandr_output()`
+  - Parse the named connected display conservatively
+  - Return the app-convention scale (`1.9`, `1.5`, etc.) when it can be determined
+  - Return `None` when parsing is ambiguous
+- [ ] Add `_apply_display_scale(self, display_name, scale=None)`.
+  - Build exactly one `xrandr --output ...` command for the passed target display
+  - For `None` or `1.0`, apply native mode, native panning, and `--scale 1x1`
+  - For non-1.0 scales, keep the current inverted xrandr scale logic and panning calculation
+  - Invalidate the xrandr cache after a successful apply
+  - Return `True` or `False`
+- [ ] Ensure the helper always acts on the passed `display_name` and never on some other currently active display.
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm failures, if any remain, are now only about the missing `enable_display()` orchestration.
+
+---
+
+## Task 3: Teach `enable_display()` to do `1.0 -> target` only when lowering scale
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Update `enable_display()` to compute whether the requested scale is lower than the target display's current effective scale.
+  - Only consider this when `scale` is not `None` and not `1.0`
+  - Compare against the **target display name being enabled**
+- [ ] If the requested scale is lower, apply `1.0` on the target display first.
+- [ ] After the temporary `1.0` reset, apply the final requested scale on that same target display.
+- [ ] If the current scale is unknown, skip the workaround and apply the requested scale directly.
+- [ ] Preserve existing verification behavior after enable.
+  - invalidate xrandr cache
+  - wait for X11 to settle
+  - verify with `is_display_active(display_name)`
+  - keep logging consistent
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm the focused tests pass.
+- [ ] Commit:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py
+  git commit -m "fix(display): reset target output before lowering scale"
+  ```
+
+---
+
+## Task 4: Verify shared OLED/E-Ink flows inherit the centralized fix
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `toggle-eink.py`
+- Verify: `Tinta4Plus.py`
+- Optional Test: `tests/test_mode_switch_state.py`
+
+- [ ] Confirm shared switch paths still call `display_mgr.enable_display(..., scale=scale)` and do not duplicate scale-reset logic.
+- [ ] Optionally add a light regression test proving the shared mode-switch path still passes the requested scale through to `DisplayManager` unchanged.
+- [ ] Do **not** duplicate low-level xrandr sequencing tests outside `DisplayManager`.
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_mode_switch_state tests.test_mode_switch_rotation -v
+  ```
+- [ ] Confirm the shared-flow tests pass.
+
+---
+
+## Task 5: Final verification before claiming success
+
+**Files:**
+- Verify: `DisplayManager.py`
+- Verify: `tests/test_display_manager_rotation.py`
+- Verify: any updated shared-flow tests
+
+- [ ] Run the full relevant automated test set:
+  ```bash
+  python -m unittest \
+    tests.test_display_manager_rotation \
+    tests.test_mode_switch_state \
+    tests.test_mode_switch_rotation \
+    tests.test_tinta4plus_ui_state -v
+  ```
+- [ ] Confirm all relevant tests pass.
+- [ ] Review the final diff:
+  ```bash
+  git diff -- DisplayManager.py tests/test_display_manager_rotation.py tests/test_mode_switch_state.py tests/test_mode_switch_rotation.py
+  ```
+- [ ] Confirm the diff only contains the intended lower-scale reset logic and focused regression coverage.
+- [ ] Manually verify on hardware.
+  - [ ] Reproduce a larger-to-smaller switch such as `1.9 -> 1.5`
+  - [ ] Confirm clipping no longer happens
+  - [ ] Confirm the temporary reset is applied on the target display being enabled
+  - [ ] Confirm increasing scale still behaves normally
+- [ ] Commit final verified state if needed:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py tests/test_mode_switch_state.py tests/test_mode_switch_rotation.py
+  git commit -m "fix(display): avoid clipping when lowering output scale"
+  ```

--- a/docs/plans/2026-04-04-randr-full-state-transition-refactor.md
+++ b/docs/plans/2026-04-04-randr-full-state-transition-refactor.md
@@ -1,0 +1,209 @@
+# RandR Full-State Transition Refactor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor display switching so every OLED/E-Ink transition applies and verifies a complete XRandR target state, including framebuffer size, preventing clipped desktops caused by stale framebuffer state.
+
+**Architecture:** Centralize all display-state math and XRandR application logic in `DisplayManager.py`. Introduce an explicit target-state representation that computes native mode, logical desktop size, xrandr transform, panning, and framebuffer together, then apply and verify that state deterministically. Keep `mode_switch.py` focused on higher-level mode orchestration, with display-state convergence delegated to `DisplayManager`.
+
+**Tech Stack:** Python 3, X11/XRandR (`xrandr`), existing `DisplayManager` and `mode_switch` modules, `unittest` / `unittest.mock`
+
+---
+
+## Task 1: Document and encode the target state shape
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Add a small internal target-state representation in `DisplayManager.py`.
+  - Keep it simple: dict or lightweight class with keys/fields for:
+    - `display_name`
+    - `native_width`
+    - `native_height`
+    - `requested_scale`
+    - `xrandr_scale_x`
+    - `xrandr_scale_y`
+    - `logical_width`
+    - `logical_height`
+    - `panning_width`
+    - `panning_height`
+    - `framebuffer_width`
+    - `framebuffer_height`
+- [ ] Add one helper that computes this target state from `display_name` and requested app scale.
+- [ ] Ensure native/unscaled state produces:
+  - `--scale 1x1`
+  - native logical size
+  - native panning
+  - native framebuffer
+- [ ] Ensure scaled state produces one consistent logical size used for geometry, panning, and framebuffer.
+- [ ] Add failing tests for the computed target-state values for:
+  - native OLED
+  - scaled OLED
+  - scaled E-Ink
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm failures are only due to missing target-state helper behavior.
+
+## Task 2: Refactor xrandr apply into full-state application
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Replace the current partial apply flow in `_apply_display_scale()` with a helper that applies the computed target state.
+- [ ] Build xrandr commands from the target-state object, not from scattered branch math.
+- [ ] Include framebuffer size in the apply path with `--fb`.
+- [ ] Preserve current behavior for unknown displays by keeping the existing fallback path.
+- [ ] Log the desired target state before running xrandr.
+- [ ] Add failing tests asserting the xrandr command includes:
+  - `--mode`
+  - `--scale`
+  - `--panning`
+  - `--fb`
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm focused tests now pass or only fail on verification behavior not yet added.
+
+## Task 3: Add post-apply verification of actual RandR state
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Add a helper that reads actual xrandr state after apply and extracts:
+  - screen framebuffer size from the `Screen 0:` line
+  - active output geometry for the target display
+- [ ] Add a verification helper that compares actual state against the computed target state.
+- [ ] Verification must confirm at minimum:
+  - target display is active
+  - framebuffer width/height are at least the expected logical width/height
+  - active output geometry matches expected logical width/height
+- [ ] Log mismatches in a structured way.
+- [ ] Add failing tests for:
+  - matching postcondition returns success
+  - framebuffer too small returns failure
+  - wrong output geometry returns failure
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm the verification tests pass.
+
+## Task 4: Add one deterministic recovery path for mismatched state
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Add one recovery helper that resets the target display to a known-good native baseline.
+  - Use the successful manual recovery shape:
+    - native mode
+    - `--scale 1x1`
+    - panning reset
+    - native framebuffer
+- [ ] Update `enable_display()` so when post-apply verification fails due to framebuffer/output mismatch, it:
+  - runs the baseline reset once
+  - reapplies the target state once
+  - verifies again
+- [ ] Do not loop indefinitely.
+- [ ] Preserve existing lower-scale-via-1.0 behavior unless the new full-state apply makes it redundant; if redundant, remove it deliberately and update tests.
+- [ ] Add failing tests for:
+  - one failed verification triggers one recovery attempt
+  - second verification success returns `True`
+  - repeated failure returns `False`
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm the recovery-path tests pass.
+
+## Task 5: Keep `mode_switch.py` orchestration thin and observable
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+- [ ] Confirm `mode_switch.py` continues to delegate display convergence to `display_mgr.enable_display(..., scale=...)`.
+- [ ] Keep the new post-switch logging in `mode_switch.py` so switch-level logs still show:
+  - `Screen 0:` state
+  - active outputs
+  - active monitors
+- [ ] Do not duplicate framebuffer repair logic in `mode_switch.py`.
+- [ ] Add/adjust tests only as needed to verify:
+  - switch flows still call `enable_display()` once per transition step
+  - post-switch snapshot logging still runs
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_mode_switch_rotation -v
+  ```
+- [ ] Confirm the switch-flow tests pass.
+
+## Task 6: Verify real switching scenarios in focused test runs
+
+**Files:**
+- Verify: `DisplayManager.py`
+- Verify: `mode_switch.py`
+- Verify: `tests/test_display_manager_rotation.py`
+- Verify: `tests/test_mode_switch_rotation.py`
+
+- [ ] Run the focused automated suite:
+  ```bash
+  python -m unittest \
+    tests.test_display_manager_rotation \
+    tests.test_mode_switch_rotation -v
+  ```
+- [ ] Review the diff:
+  ```bash
+  git diff -- DisplayManager.py mode_switch.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py
+  ```
+- [ ] Confirm the diff shows one coherent refactor toward full-state application and verification.
+- [ ] Manually verify on hardware:
+  - switch OLED native -> OLED scaled
+  - switch OLED scaled -> lower OLED scaled
+  - switch OLED -> E-Ink
+  - switch E-Ink -> OLED
+- [ ] After each transition, confirm:
+  - no clipped desktop
+  - framebuffer matches or exceeds logical output geometry
+  - logs show desired state and resulting state
+- [ ] Commit:
+  ```bash
+  git add DisplayManager.py mode_switch.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py
+  git commit -m "fix(display): apply verified full RandR target state"
+  ```
+
+## Task 7: Optional cleanup if the old incremental logic becomes obsolete
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Re-evaluate whether the old special-case lower-scale reset logic is still needed once full-state apply plus verification exists.
+- [ ] If full-state apply reliably covers that case, remove obsolete branching and simplify `enable_display()`.
+- [ ] Update tests to validate the simpler contract.
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Commit cleanup separately:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py
+  git commit -m "refactor(display): simplify scale transition flow"
+  ```
+
+---
+
+## Definition of Done
+
+- [ ] `DisplayManager` computes one explicit target state per display apply.
+- [ ] The apply path includes framebuffer management with `--fb`.
+- [ ] Every display transition verifies postconditions against actual xrandr state.
+- [ ] One deterministic recovery path exists for framebuffer/output mismatch.
+- [ ] `mode_switch.py` stays orchestration-only and does not duplicate display repair logic.
+- [ ] Focused automated tests pass.
+- [ ] Manual hardware verification confirms no clipped desktop after repeated switching.

--- a/docs/plans/2026-04-04-remove-blind-sleeps-with-readiness-polls.md
+++ b/docs/plans/2026-04-04-remove-blind-sleeps-with-readiness-polls.md
@@ -1,0 +1,489 @@
+# Remove Blind Sleeps with Readiness Polls Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate fixed `time.sleep(...)` calls from production code and replace them with bounded, observable readiness polling so display switching converges as fast as the system is actually ready while preserving reliability.
+
+**Architecture:** Introduce small monotonic-time polling helpers around concrete system predicates instead of fixed delays. Keep RandR readiness checks centralized in `DisplayManager`, keep mode-switch hardware readiness checks in `mode_switch.py`, and replace GUI helper reconnect sleeps with socket reconnect polling. Poll loops must have explicit timeouts, short intervals, structured logging, and fail with the same or better safety semantics as today.
+
+**Tech Stack:** Python 3, X11/XRandR (`xrandr`), existing helper HTTP API, `subprocess`, `time.monotonic`, `unittest` / `unittest.mock`
+
+---
+
+## Sleep inventory to remove
+
+Current production-code sleeps to eliminate:
+
+- `mode_switch.py`
+  - `switch_to_eink()`: `time.sleep(0.5)` after helper E-Ink/frontlight prep
+  - `switch_to_oled()`: `time.sleep(0.5)` after privacy image launch
+  - `switch_to_oled()`: `time.sleep(2.0)` after disable-eink/disable-frontlight prep
+- `DisplayManager.py`
+  - `enable_display()`: `time.sleep(self.XRANDR_APPLY_DELAY)`
+  - `finalize_single_display()`: three `time.sleep(self.XRANDR_APPLY_DELAY)` sites
+  - `disable_display()`: `time.sleep(self.XRANDR_APPLY_DELAY)`
+  - `display_fullscreen_image()`: `time.sleep(self.IMAGE_DISPLAY_DELAY)` in both `feh` and `imv` branches
+- `Tinta4Plus.py`
+  - `attempt_helper_restart()`: `time.sleep(0.5)` before reconnect attempt
+
+The finished diff should remove all of the above from production code.
+
+---
+
+## Task 1: Add failing tests that describe poll-based behavior instead of fixed waits
+
+**Files:**
+- Modify: `tests/test_display_manager_rotation.py`
+- Modify: `tests/test_mode_switch_rotation.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+- Verify: `DisplayManager.py`
+- Verify: `mode_switch.py`
+- Verify: `Tinta4Plus.py`
+
+### Step 1: Add failing tests for RandR polling in `DisplayManager`
+
+Add tests proving the display methods do not depend on a single blind sleep and instead keep checking until the target predicate becomes true.
+
+Coverage to add:
+- `enable_display()` polls `is_display_active(display_name)` until it becomes true, then returns success.
+- `enable_display()` returns false after timeout if `is_display_active(display_name)` never becomes true.
+- `disable_display()` polls until `is_display_active(display_name)` becomes false.
+- `finalize_single_display()` polls `_verify_display_target_state(...)` until it succeeds.
+- the retry path in `finalize_single_display()` also uses polling after the baseline reset and reapply.
+
+Use `side_effect` sequences like `[False, False, True]` to prove repeated checks happen.
+
+### Step 2: Add failing tests for mode-switch prep polling
+
+Add tests proving:
+- `switch_to_eink()` waits on a helper readiness predicate instead of calling `time.sleep(0.5)`.
+- `switch_to_oled()` waits on a helper readiness predicate instead of calling `time.sleep(2.0)`.
+- `switch_to_oled()` waits for privacy image readiness via a polling helper instead of `time.sleep(0.5)`.
+- no production path in `mode_switch.py` calls `time.sleep(...)` during a successful switch.
+
+The tests should mock dedicated helper functions you will add, not raw `time.sleep`.
+
+### Step 3: Add failing tests for GUI reconnect polling
+
+Add tests proving:
+- `attempt_helper_restart()` retries connection until it succeeds or times out.
+- it no longer depends on a single fixed `time.sleep(0.5)` before reconnect.
+- on success, it still triggers `_reconcile_from_live_state()` and schedules the UI follow-up exactly as before.
+
+### Step 4: Run the focused tests and confirm expected failures
+
+Run:
+```bash
+python3 -m unittest -v \
+  tests.test_display_manager_rotation \
+  tests.test_mode_switch_rotation \
+  tests.test_tinta4plus_ui_state
+```
+
+Expected:
+- FAIL because the new poll helpers and retry orchestration do not exist yet.
+
+### Step 5: Commit the red tests
+
+```bash
+git add tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py tests/test_tinta4plus_ui_state.py
+git commit -m "test(display): specify readiness polling behavior"
+```
+
+---
+
+## Task 2: Add one bounded polling primitive and use it for RandR state convergence
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+### Step 1: Add a generic polling helper to `DisplayManager`
+
+Add a helper such as:
+```python
+def _poll_until(self, predicate, *, timeout_s, interval_s, description):
+    deadline = time.monotonic() + timeout_s
+    last_value = None
+    while time.monotonic() < deadline:
+        last_value = predicate()
+        if last_value:
+            return True
+    return False
+```
+
+Implementation requirements:
+- use `time.monotonic()`
+- small poll interval constant, e.g. `0.05` or `0.1`
+- explicit timeout constants for:
+  - output active/inactive convergence
+  - compact final-state verification
+  - image viewer readiness
+- log start / success / timeout with the `description`
+- do **not** call `time.sleep`; use a non-blocking wait strategy only inside the poll helper if needed via `select`, `Event.wait`, or short monotonic pacing logic. If you choose to pace with a tiny wait primitive, keep it isolated in one helper and remove all direct production sleeps elsewhere.
+
+### Step 2: Convert `enable_display()` to poll on actual display activation
+
+Replace `time.sleep(self.XRANDR_APPLY_DELAY)` with polling for:
+- `self.is_display_active(display_name)`
+
+Success condition:
+- returns true as soon as the display is active
+
+Failure condition:
+- logs timeout and returns false
+
+### Step 3: Convert `disable_display()` to poll on actual display deactivation
+
+Replace `time.sleep(self.XRANDR_APPLY_DELAY)` with polling for:
+- `not self.is_display_active(display_name)`
+
+### Step 4: Convert `finalize_single_display()` to poll on target-state verification
+
+Replace each post-apply sleep with polling for:
+- `self._verify_display_target_state(display_name, target_state)`
+
+Retry behavior requirements:
+- first apply polls for verified final state
+- on failure, reset baseline once
+- poll for baseline activation only if needed for correctness
+- reapply target state once
+- poll again for verified final state
+- no unbounded loops
+
+### Step 5: Remove stale delay constants if they are no longer needed
+
+Delete or rename:
+- `XRANDR_APPLY_DELAY`
+
+Replace with timeout/interval constants such as:
+- `XRANDR_POLL_INTERVAL`
+- `XRANDR_ACTIVATION_TIMEOUT`
+- `XRANDR_FINALIZE_TIMEOUT`
+
+### Step 6: Run focused tests
+
+Run:
+```bash
+python3 -m unittest -v tests.test_display_manager_rotation
+```
+
+Expected:
+- PASS for the new polling tests
+- existing display-manager tests stay green
+
+### Step 7: Commit
+
+```bash
+git add DisplayManager.py tests/test_display_manager_rotation.py
+git commit -m "refactor(display): poll for RandR convergence"
+```
+
+---
+
+## Task 3: Replace mode-switch prep sleeps with helper/device readiness polling
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+- Verify: helper client API already used by `helper_command(...)`
+
+### Step 1: Define the observable predicates for prep readiness
+
+Add small mode-switch helpers such as:
+- `_wait_for_eink_enabled(helper, logger, timeout_s=...)`
+- `_wait_for_eink_disabled(helper, logger, timeout_s=...)`
+- `_wait_for_frontlight_state(helper, logger, enabled, timeout_s=...)`
+- `_wait_for_privacy_image_ready(display_mgr, logger, image_process, timeout_s=...)`
+
+Use observable state only. Preferred predicates:
+- helper state endpoint / frontlight endpoint if already available through the helper client
+- process liveness plus X11 window detection for privacy image if available
+- bounded timeout with useful warning logs on failure
+
+Do **not** add another hardcoded dwell time.
+
+### Step 2: Replace E-Ink prep sleep with readiness polling
+
+In `switch_to_eink()`:
+- keep `enable-eink`
+- keep optional `enable-frontlight`
+- replace `time.sleep(0.5)` with one bounded wait that confirms the E-Ink path is ready for display convergence
+
+Recommended predicate order:
+- confirm helper reports E-Ink enabled
+- if frontlight requested, confirm frontlight enabled / brightness applied
+
+### Step 3: Replace OLED prep sleep with readiness polling
+
+In `switch_to_oled()`:
+- after `disable-eink`, poll until helper reports E-Ink disabled
+- after `disable-frontlight`, poll until helper reports frontlight disabled
+- remove `time.sleep(2.0)` entirely
+
+### Step 4: Replace privacy-image launch sleep with readiness polling
+
+Update the privacy-image path so `display_fullscreen_image()` or a new companion helper returns enough information to wait for readiness without a fixed sleep.
+
+Recommended approach:
+- poll for `image_process.poll() is None`
+- if running under X11 and a tool-free predicate is available, also poll for a mapped client window owned by that PID
+- if no stronger signal is available, treat a still-running process after a short bounded poll as ready and document the limitation in code comments
+
+### Step 5: Run focused mode-switch tests
+
+Run:
+```bash
+python3 -m unittest -v tests.test_mode_switch_rotation tests.test_mode_switch_state
+```
+
+Expected:
+- PASS
+- no direct production `time.sleep(...)` remains in `mode_switch.py`
+
+### Step 6: Commit
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py
+git commit -m "refactor(mode-switch): replace prep sleeps with readiness polls"
+```
+
+---
+
+## Task 4: Remove image-viewer sleeps from `DisplayManager.display_fullscreen_image()`
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+- Verify: callers in `mode_switch.py`
+
+### Step 1: Add failing or expanded tests for image-launch readiness
+
+Add tests proving:
+- `display_fullscreen_image()` no longer sleeps after `Popen`
+- it returns a process object immediately when launch succeeds
+- a separate readiness helper performs any bounded readiness polling
+
+### Step 2: Refactor image display API
+
+Refactor toward one of these patterns:
+
+Preferred:
+```python
+process = display_fullscreen_image(...)
+wait_for_fullscreen_image(process, ...)
+```
+
+Alternative:
+```python
+process, ready_checker = display_fullscreen_image(...)
+```
+
+Keep responsibilities clear:
+- launch function launches only
+- wait function verifies readiness only
+
+### Step 3: Remove `IMAGE_DISPLAY_DELAY`
+
+Delete:
+- `IMAGE_DISPLAY_DELAY`
+
+Replace with:
+- `IMAGE_READY_TIMEOUT`
+- `IMAGE_READY_POLL_INTERVAL`
+
+### Step 4: Run focused tests
+
+Run:
+```bash
+python3 -m unittest -v tests.test_display_manager_rotation tests.test_mode_switch_rotation
+```
+
+### Step 5: Commit
+
+```bash
+git add DisplayManager.py mode_switch.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py
+git commit -m "refactor(display): separate image launch from readiness polling"
+```
+
+---
+
+## Task 5: Replace GUI helper reconnect sleep with retry polling
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Test: `tests/test_tinta4plus_ui_state.py`
+
+### Step 1: Introduce a reconnect polling helper
+
+Add a helper such as:
+```python
+def _poll_helper_reconnect(self, timeout_s, interval_s):
+    ...
+```
+
+Predicate:
+- `self.helper.connect(self.SOCKET_PATH, timeout=self.SOCKET_TIMEOUT)` succeeds
+
+Requirements:
+- bounded timeout
+- logs retries at debug level
+- returns immediately on first success
+- no direct `time.sleep(0.5)` call
+
+### Step 2: Update `attempt_helper_restart()` to use the polling helper
+
+Preserve existing success behavior:
+- reconnect message
+- event watcher start
+- `_reconcile_from_live_state()`
+- `self.root.after(500, self.check_ec_status)`
+
+Preserve existing failure behavior:
+- error log
+- status update
+- error dialog
+
+### Step 3: Run focused tests
+
+Run:
+```bash
+python3 -m unittest -v tests.test_tinta4plus_ui_state
+```
+
+### Step 4: Commit
+
+```bash
+git add Tinta4Plus.py tests/test_tinta4plus_ui_state.py
+git commit -m "refactor(gui): poll for helper reconnect readiness"
+```
+
+---
+
+## Task 6: Audit the tree and prove all production sleeps are gone
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `DisplayManager.py`
+- Verify: `Tinta4Plus.py`
+- Verify: any helper modules added
+
+### Step 1: Search for remaining production sleeps
+
+Run:
+```bash
+rg -n "time\.sleep\(" -S mode_switch.py DisplayManager.py Tinta4Plus.py HelperDaemon.py
+```
+
+Expected:
+- no results in production files
+- tests may still use mocked timing or helper utilities as needed
+
+### Step 2: Search for old delay constants
+
+Run:
+```bash
+rg -n "XRANDR_APPLY_DELAY|IMAGE_DISPLAY_DELAY" -S .
+```
+
+Expected:
+- no active production references
+- if mentioned in docs/tests, update or delete as appropriate
+
+### Step 3: Run the relevant automated suite
+
+Run:
+```bash
+python3 -m unittest -v \
+  tests.test_display_manager_rotation \
+  tests.test_mode_switch_rotation \
+  tests.test_mode_switch_state \
+  tests.test_tinta4plus_ui_state \
+  tests.test_logging_targets
+```
+
+Expected:
+- PASS
+
+### Step 4: Commit
+
+```bash
+git add DisplayManager.py mode_switch.py Tinta4Plus.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py
+git commit -m "refactor: remove blind sleeps from display switching"
+```
+
+---
+
+## Task 7: Hardware verification with timestamp comparison
+
+**Files:**
+- Verify: runtime behavior only
+
+### Step 1: Measure before/after using existing timestamped logs
+
+Use `/tmp/TintaHelper.log` and current runtime logs to compare:
+- switch-to-E-Ink start → `Now using E-Ink`
+- switch-to-OLED start → `Now using OLED`
+- helper prep durations
+- convergence durations
+
+### Step 2: Run repeated live roundtrips
+
+Run several times:
+```bash
+python3 toggle-eink.py
+python3 toggle-eink.py
+```
+
+Collect at least:
+- 5 successful E-Ink switches
+- 5 successful OLED switches
+
+### Step 3: Verify readiness behavior is correct
+
+Confirm:
+- no regression in final active output
+- no regression in theme switching
+- no regression in touch/input remapping
+- no new hangs from unbounded polls
+- logs show timeout-based failures instead of silent waiting
+
+### Step 4: Verify sleep removal did not increase flakiness
+
+Check for:
+- more `BadMatch` churn
+- incomplete privacy-image behavior
+- helper reconnect failures
+- stale frontlight state
+
+### Step 5: Final review
+
+Run:
+```bash
+git diff -- DisplayManager.py mode_switch.py Tinta4Plus.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py
+```
+
+Confirm the diff:
+- removes blind sleeps
+- adds bounded polling only
+- does not introduce background threads or uncontrolled concurrency
+
+### Step 6: Final commit if needed
+
+```bash
+git add DisplayManager.py mode_switch.py Tinta4Plus.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py tests/test_tinta4plus_ui_state.py docs/plans/2026-04-04-remove-blind-sleeps-with-readiness-polls.md
+git commit -m "docs(plan): replace blind sleeps with readiness polling"
+```
+
+---
+
+## Design constraints for implementation
+
+- Prefer **observable system state** over elapsed time.
+- Every poll must have a **timeout** and a **clear log message** on timeout.
+- No unbounded retries.
+- Keep xrandr operations serialized.
+- Do not add threads unless tests prove they are necessary.
+- Use the smallest number of new abstractions needed.
+- If an operation has no trustworthy readiness signal, make that explicit in code and use the narrowest bounded fallback possible.
+- Preserve current error-handling and rollback semantics unless a test is updated deliberately.

--- a/docs/plans/2026-04-04-topology-aware-display-finalization.md
+++ b/docs/plans/2026-04-04-topology-aware-display-finalization.md
@@ -1,0 +1,318 @@
+# Topology-Aware Display Finalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Split display switching into transition-safe activation and post-disable finalization so framebuffer shrink only happens after the old output is off.
+
+**Architecture:** Keep `DisplayManager.py` focused on low-level RandR primitives and explicit single-output finalization. Move topology sequencing responsibility to `mode_switch.py`, where switch intent is already known. During a switch, first activate the target output in a transition-safe way, then disable the old output, then apply one final compact single-output layout and verify that steady state.
+
+**Tech Stack:** Python 3, `unittest`, `unittest.mock`, `xrandr`, existing `DisplayManager` / `mode_switch` modules
+
+---
+
+### Task 1: Add failing switch-flow tests for post-disable finalization
+
+**Files:**
+- Modify: `tests/test_mode_switch_rotation.py`
+- Reference: `mode_switch.py`
+
+**Step 1: Write the failing test**
+
+Add one test for `switch_to_eink(...)` and one for `switch_to_oled(...)` proving the switch flow performs a final compact-layout call only after disabling the old output.
+
+```python
+self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_OLED)
+self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+```
+
+and:
+
+```python
+self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
+self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+```
+
+Also assert ordering with `mock_calls` or call indices so finalization is after the disable step.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+python -m unittest tests.test_mode_switch_rotation -v
+```
+
+Expected: FAIL because `DisplayManager` has no `finalize_single_display(...)` call in switch flow yet.
+
+**Step 3: Write minimal implementation**
+
+Do not touch production code yet beyond what is needed for the tests to compile if a temporary stub is unavoidable.
+
+**Step 4: Run test to verify it still fails for the right reason**
+
+Run:
+```bash
+python -m unittest tests.test_mode_switch_rotation -v
+```
+
+Expected: FAIL specifically on missing finalization behavior or wrong call order.
+
+**Step 5: Commit**
+
+Do not commit yet. This task is intentionally left red until production changes land.
+
+---
+
+### Task 2: Add failing `DisplayManager` tests for explicit single-output finalization
+
+**Files:**
+- Modify: `tests/test_display_manager_rotation.py`
+- Reference: `DisplayManager.py`
+
+**Step 1: Write the failing test**
+
+Add tests for a new `finalize_single_display(display_name, scale)` method proving:
+- scaled dimensions are rounded up with `math.ceil(...)`
+- the resulting xrandr command includes `--mode`, `--scale`, `--panning`, and `--fb`
+- `--fb` matches the final single-output logical size
+
+Example target assertion for E-Ink at `1.75`:
+
+```python
+ok = self.manager.finalize_single_display("eDP-2", scale=1.75)
+self.assertTrue(ok)
+command = run_mock.call_args.args[0]
+self.assertIn("--fb", command)
+self.assertIn("1463x915", command)
+```
+
+Add one verification test proving final-state verification succeeds for:
+
+```text
+Screen 0: minimum 8 x 8, current 1463 x 915, maximum 32767 x 32767
+eDP-2 connected primary 1463x915+0+0 normal (...)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+python -m unittest tests.test_display_manager_rotation -v
+```
+
+Expected: FAIL because `finalize_single_display(...)` does not exist and current target-state math floors instead of ceils.
+
+**Step 3: Write minimal implementation**
+
+Do not implement yet beyond the minimum needed to keep tests focused on the desired behavior.
+
+**Step 4: Run test to verify it still fails for the right reason**
+
+Run:
+```bash
+python -m unittest tests.test_display_manager_rotation -v
+```
+
+Expected: FAIL on missing finalization behavior or incorrect `1462x914` sizing.
+
+**Step 5: Commit**
+
+Do not commit yet. This task remains red until production code lands.
+
+---
+
+### Task 3: Refactor `DisplayManager` into activation vs. finalization primitives
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+**Step 1: Implement transition-safe activation behavior**
+
+Adjust `enable_display(display_name, scale=None)` so it no longer tries to force the final compact single-output framebuffer during activation.
+
+Keep the behavior narrow:
+- activate the output and requested mode/scale in a transition-safe way
+- do not shrink framebuffer to a single-output steady state while another output may still be active
+- keep unknown-display `--auto` fallback unchanged
+
+If needed, introduce a private helper such as:
+
+```python
+def _activate_display_transition_safe(self, display_name, scale=None):
+    ...
+```
+
+**Step 2: Implement explicit single-output finalization**
+
+Add:
+
+```python
+def finalize_single_display(self, display_name, scale=None):
+    ...
+```
+
+This method should:
+- compute logical width/height using `math.ceil(native / scale)`
+- build one exact final target state for one active output
+- run `xrandr` with `--mode`, `--scale`, `--panning`, `--fb`
+- verify the final steady state after the apply
+- return `True` only if final-state verification passes
+
+**Step 3: Keep verification focused on steady state**
+
+Reuse or simplify the current verification helpers so the strongest verification is performed from `finalize_single_display(...)`, not from the transition-safe activation path.
+
+Expected final verified state shape:
+- framebuffer equals final logical size
+- target output geometry equals final logical size
+- target output is active
+
+**Step 4: Run targeted tests**
+
+Run:
+```bash
+python -m unittest tests.test_display_manager_rotation -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add DisplayManager.py tests/test_display_manager_rotation.py
+git commit -m "refactor(display): split activation from finalization"
+```
+
+---
+
+### Task 4: Update mode-switch sequencing to finalize only after old output is off
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+**Step 1: Update `switch_to_eink(...)` sequencing**
+
+After successful helper enable and after `disable_display(DISPLAY_OLED)`, add:
+
+```python
+if not display_mgr.finalize_single_display(DISPLAY_EINK, scale=scale):
+    logger.error("Failed to finalize E-Ink output layout")
+    return False
+```
+
+Do this before touch reconciliation / orientation / post-switch snapshot logging.
+
+**Step 2: Update `switch_to_oled(...)` sequencing**
+
+After successful `disable_display(DISPLAY_EINK)`, add:
+
+```python
+if not display_mgr.finalize_single_display(DISPLAY_OLED, scale=scale):
+    logger.error("Failed to finalize OLED output layout")
+    return False
+```
+
+Also place this before touch reconciliation / orientation / snapshot logging.
+
+**Step 3: Keep existing orchestration behavior intact**
+
+Do not change unrelated responsibilities:
+- helper commands
+- theme switching
+- DPMS handling
+- privacy image flow
+- touch reconciliation
+- orientation application
+- snapshot logging
+
+Only insert the new explicit post-disable finalization step.
+
+**Step 4: Run targeted tests**
+
+Run:
+```bash
+python -m unittest tests.test_mode_switch_rotation -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py
+git commit -m "fix(mode-switch): finalize layout after old output is disabled"
+```
+
+---
+
+### Task 5: Run combined regression verification
+
+**Files:**
+- No code changes required
+
+**Step 1: Run the full targeted test set**
+
+Run:
+```bash
+python -m unittest tests.test_display_manager_rotation tests.test_mode_switch_rotation -v
+```
+
+Expected: all tests PASS.
+
+**Step 2: Reproduce via CLI on real hardware**
+
+Run:
+```bash
+python toggle-eink.py
+xrandr --query
+xrandr --listactivemonitors
+```
+
+Expected after switching to E-Ink:
+- exit code `0`
+- no `specified screen ... not large enough` error
+- `Screen 0: current 1463 x 915` (or whatever final ceil-based steady state is for current configured scale)
+- only E-Ink active in `--listactivemonitors`
+
+Then run the reverse direction:
+
+```bash
+python toggle-eink.py
+xrandr --query
+xrandr --listactivemonitors
+```
+
+Expected after switching back to OLED:
+- exit code `0`
+- no clipping
+- one active OLED monitor
+- framebuffer matches final OLED-only logical geometry
+
+**Step 3: If hardware verification fails, stop and capture evidence**
+
+Collect:
+```bash
+python toggle-eink.py 2>&1 | tee /tmp/toggle-eink.log
+xrandr --query > /tmp/xrandr-query.txt
+xrandr --listactivemonitors > /tmp/xrandr-monitors.txt
+```
+
+Do not guess. Inspect the actual topology and update the design only if evidence shows a new failure mode.
+
+**Step 4: Commit final integrated change if verification passes**
+
+```bash
+git add DisplayManager.py mode_switch.py tests/test_display_manager_rotation.py tests/test_mode_switch_rotation.py
+git commit -m "fix(display): finalize single-output layout after switch"
+```
+
+**Step 5: Summarize verification evidence**
+
+Record in the handoff note:
+- exact unittest command run
+- exact CLI commands run
+- final `xrandr --query` steady-state lines for both directions
+- confirmation that clipping no longer occurs

--- a/docs/plans/2026-04-04-touch-input-logging-design.md
+++ b/docs/plans/2026-04-04-touch-input-logging-design.md
@@ -1,0 +1,86 @@
+# Touch Input Logging Design
+
+**Goal:** Add INFO-level logging around touch/input X11 command execution so future rotation and display-switch failures can be diagnosed from logs without manual `xinput` inspection.
+
+## Problem
+
+Current touch/input handling in `mode_switch.py` has only coarse logging:
+- high-level switch/rotation flows log success or warning outcomes
+- `_run_xinput(...)` only logs failures
+- successful `xinput` commands, matched device IDs, and chosen outputs are not logged
+
+That makes it hard to tell after the fact:
+- whether input remap actually ran
+- which devices were matched for OLED vs E-Ink
+- which IDs were enabled/disabled/mapped
+- which exact command failed
+
+## Requirements
+
+- Log touch-related `xinput` commands at **INFO** level during normal runs.
+- Keep behavior unchanged; this is diagnostics only.
+- Log enough context to diagnose future failures without reproducing manually.
+- Keep failure logging detailed and structured.
+- Add test coverage for the new logging behavior.
+
+## Approach Options
+
+### Option A: Log only inside `_run_xinput(...)`
+Pros:
+- Smallest code change
+- Central place for command execution
+
+Cons:
+- Does not explain why a command ran
+- Does not log device matching or target mode decisions
+
+### Option B: Log both command execution and input-mode decisions (**recommended**)
+Pros:
+- Gives both low-level and high-level context
+- Lets us correlate target mode, matched devices, and exact commands
+- Minimal behavior risk
+
+Cons:
+- Slightly noisier logs
+
+### Option C: Add separate debug dump helper
+Pros:
+- More structured snapshots
+
+Cons:
+- More code
+- More than needed for the current diagnostic need
+
+## Recommended Design
+
+Implement Option B.
+
+### Command-level logging
+In `mode_switch.py`:
+- `_run_xinput(logger, args)` logs the exact command before execution
+- on success, log command success and trimmed stdout if present
+- on failure, log command, return code details, and stderr/stdout if present
+
+### Decision-level logging
+In `_apply_input_mode(logger, target)`:
+- log matched E-Ink and OLED devices by ID and name
+- log selected target output
+- log the enable/disable sets
+- log final success/failure summary
+
+### Non-goals
+- No touch behavior changes
+- No rotation math changes
+- No CTM/Wacom-specific fixes yet
+
+## Testing
+
+Extend `tests/test_mode_switch_input_mode.py` to cover:
+- `_run_xinput(...)` logs before and after successful command execution
+- `_run_xinput(...)` logs detailed failure information
+- `_apply_input_mode(...)` logs mode decisions and final summary
+
+## Files
+
+- Modify: `mode_switch.py`
+- Modify: `tests/test_mode_switch_input_mode.py`

--- a/docs/plans/2026-04-04-touch-input-logging.md
+++ b/docs/plans/2026-04-04-touch-input-logging.md
@@ -1,0 +1,68 @@
+# Touch Input Logging Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add INFO-level logging for touch/input X11 commands and input-mode decisions so future touch failures can be diagnosed from normal logs.
+
+**Architecture:** Extend the existing `mode_switch.py` XInput helper layer rather than adding new runtime paths. Keep `_run_xinput(...)` responsible for exact command execution logging, and keep `_apply_input_mode(...)` responsible for logging device matching and enable/disable/map decisions.
+
+**Tech Stack:** Python 3, `subprocess`, `logging`, `unittest`, `unittest.mock`.
+
+---
+
+### Task 1: Add failing logging tests for `_run_xinput(...)`
+
+**Files:**
+- Modify: `tests/test_mode_switch_input_mode.py`
+- Modify: `mode_switch.py`
+
+**Step 1: Write the failing tests**
+- Add a test proving `_run_xinput(...)` logs the command before execution and logs success for a successful `subprocess.run(...)` result.
+- Add a test proving `_run_xinput(...)` logs a detailed failure message for a `CalledProcessError`.
+
+**Step 2: Run test to verify it fails**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: FAIL because the new log assertions are not satisfied.
+
+**Step 3: Write minimal implementation**
+- Update `_run_xinput(...)` to log `xinput <args>` at INFO before execution.
+- On success, log success and trimmed stdout if present.
+- On failure, log command plus available stderr/stdout details.
+
+**Step 4: Run test to verify it passes**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: PASS.
+
+### Task 2: Add failing logging tests for `_apply_input_mode(...)`
+
+**Files:**
+- Modify: `tests/test_mode_switch_input_mode.py`
+- Modify: `mode_switch.py`
+
+**Step 1: Write the failing tests**
+- Add a test proving `_apply_input_mode(...)` logs matched device groups, target output, and the final success summary.
+
+**Step 2: Run test to verify it fails**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: FAIL because the summary log does not exist yet.
+
+**Step 3: Write minimal implementation**
+- Add INFO-level summary logging for matched device groups, target output, enable IDs, disable IDs, and final result.
+
+**Step 4: Run test to verify it passes**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: PASS.
+
+### Task 3: Focused verification
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `tests/test_mode_switch_input_mode.py`
+
+**Step 1: Run focused tests**
+Run: `python -m unittest tests.test_mode_switch_input_mode -v`
+Expected: PASS.
+
+**Step 2: Review diff**
+Run: `git diff -- mode_switch.py tests/test_mode_switch_input_mode.py docs/plans/2026-04-04-touch-input-logging-design.md docs/plans/2026-04-04-touch-input-logging.md`
+Expected: logging-only production changes plus tests/docs.

--- a/docs/plans/2026-04-04-touch-recovery-after-rotate-and-switch.md
+++ b/docs/plans/2026-04-04-touch-recovery-after-rotate-and-switch.md
@@ -1,0 +1,139 @@
+# Touch Recovery After Rotate and Switch Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Detect when the expected touch stack is disabled after display rotate/switch operations and re-apply the shared input mode automatically.
+
+**Architecture:** Add small shared helpers in `mode_switch.py` to identify expected touch devices for the active target and detect whether any of them are enabled. Build a shared recovery helper that re-runs `_apply_input_mode(...)` and verifies the result. Invoke that helper after successful OLED/E-Ink switches and after successful GUI orientation toggles.
+
+**Tech Stack:** Python 3, X11/XInput (`xinput`), tkinter, `unittest`, `unittest.mock`.
+
+---
+
+### Task 1: Add failing tests for touch-health detection helpers
+
+**Files:**
+- Modify: `tests/test_mode_switch_input_mode.py`
+- Modify: `mode_switch.py`
+
+**Step 1: Write the failing tests**
+- Add a test for a helper that returns expected device IDs for target `eink` from matched ITE devices.
+- Add a test for a helper that returns expected device IDs for target `oled` from matched Wacom devices.
+- Add a test for a helper that reports touch healthy when at least one expected device is enabled.
+- Add a test for a helper that reports touch busted when all expected devices are disabled.
+
+**Step 2: Run test to verify it fails**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: FAIL because the new helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+- Add helper(s) in `mode_switch.py` to:
+  - collect expected device IDs for a target
+  - inspect `Device Enabled` state for those devices
+  - report healthy vs busted
+- Keep implementation small and fully shared.
+
+**Step 4: Run test to verify it passes**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: PASS.
+
+### Task 2: Add failing tests for shared recovery helper
+
+**Files:**
+- Modify: `tests/test_mode_switch_input_mode.py`
+- Modify: `mode_switch.py`
+
+**Step 1: Write the failing tests**
+- Add a test proving recovery does nothing when touch is already healthy.
+- Add a test proving recovery re-runs `_apply_input_mode(target)` when touch is busted.
+- Add a test proving recovery verifies again after re-applying input mode.
+- Add a test proving recovery logs a warning if touch is still busted after retry.
+
+**Step 2: Run test to verify it fails**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: FAIL because the recovery helper does not exist yet.
+
+**Step 3: Write minimal implementation**
+- Add a shared helper such as `ensure_touch_available(logger, target)`.
+- It should:
+  - check whether touch is healthy for the target
+  - if busted, log warning and re-run `_apply_input_mode(target)`
+  - verify again once
+  - log final success or persistent failure
+- Keep recovery bounded to one retry for now.
+
+**Step 4: Run test to verify it passes**
+Run: `python -m unittest tests.test_mode_switch_input_mode.ApplyInputModeTests -v`
+Expected: PASS.
+
+### Task 3: Hook recovery into shared switch paths
+
+**Files:**
+- Modify: `mode_switch.py`
+- Modify: `tests/test_mode_switch_rotation.py`
+
+**Step 1: Write the failing tests**
+- Add a test proving `switch_to_eink(...)` invokes touch recovery after successful input-mode application.
+- Add a test proving `switch_to_oled(...)` invokes touch recovery after successful input-mode application.
+- Keep failures warning-only so successful display switching still returns success.
+
+**Step 2: Run test to verify it fails**
+Run: `python -m unittest tests.test_mode_switch_rotation -v`
+Expected: FAIL because recovery is not called yet.
+
+**Step 3: Write minimal implementation**
+- In `switch_to_eink(...)`, call the shared recovery helper after `_apply_input_mode("eink")` and any stored orientation re-apply path.
+- In `switch_to_oled(...)`, call the shared recovery helper after `_apply_input_mode("oled")` and any stored orientation re-apply path.
+- Keep recovery warning-only.
+
+**Step 4: Run test to verify it passes**
+Run: `python -m unittest tests.test_mode_switch_rotation -v`
+Expected: PASS.
+
+### Task 4: Hook recovery into GUI orientation toggle
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+**Step 1: Write the failing tests**
+- Add a test proving a successful UI orientation toggle invokes shared touch recovery for the current target.
+- Keep existing input-remap behavior assertions intact.
+
+**Step 2: Run test to verify it fails**
+Run: `python -m unittest tests.test_tinta4plus_ui_state -v`
+Expected: FAIL because orientation toggle only re-applies input mode today.
+
+**Step 3: Write minimal implementation**
+- Import and call the shared recovery helper after successful orientation remap.
+- Preserve current UI success/failure behavior.
+
+**Step 4: Run test to verify it passes**
+Run: `python -m unittest tests.test_tinta4plus_ui_state -v`
+Expected: PASS.
+
+### Task 5: Focused verification
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `Tinta4Plus.py`
+- Verify: `tests/test_mode_switch_input_mode.py`
+- Verify: `tests/test_mode_switch_rotation.py`
+- Verify: `tests/test_tinta4plus_ui_state.py`
+
+**Step 1: Run focused tests**
+Run:
+```bash
+python -m unittest \
+  tests.test_mode_switch_input_mode \
+  tests.test_mode_switch_rotation \
+  tests.test_tinta4plus_ui_state -v
+```
+Expected: PASS.
+
+**Step 2: Review diff**
+Run:
+```bash
+git diff -- mode_switch.py Tinta4Plus.py tests/test_mode_switch_input_mode.py tests/test_mode_switch_rotation.py tests/test_tinta4plus_ui_state.py docs/plans/2026-04-04-touch-recovery-after-rotate-and-switch.md
+```
+Expected: shared touch recovery changes plus tests only.

--- a/docs/plans/2026-04-04-unified-touch-reconcile-on-activation.md
+++ b/docs/plans/2026-04-04-unified-touch-reconcile-on-activation.md
@@ -1,0 +1,131 @@
+# Unified Touch Reconcile On Activation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unify touchscreen health-check/reset behavior behind one shared reconciler and invoke it consistently after mode switches, orientation changes, lid-driven rotation, and when either app window becomes active.
+
+**Architecture:** Keep low-level xinput probing/remap logic in `mode_switch.py`, but replace scattered `ensure_touch_available(...)` policy calls with a single shared coordinator that can either use an explicit target (`eink`/`oled`) or derive the current target from live display state. In `Tinta4Plus.py`, all GUI-triggered touch recovery paths should call that one coordinator, with a debounced activation hook bound to both the root window and the floating refresh button window.
+
+**Tech Stack:** Python 3, tkinter, X11/XInput (`xinput`), `unittest`, `unittest.mock`.
+
+---
+
+### Task 1: Add a single shared touch reconciler in `mode_switch.py`
+
+**Files:**
+- Modify: `mode_switch.py`
+- Modify: `tests/test_mode_switch_input_mode.py`
+
+**Checklist:**
+- [ ] Add failing tests for a new public reconciler function in `tests/test_mode_switch_input_mode.py`.
+- [ ] Cover explicit-target behavior: when called with `target="eink"`, it should delegate to `ensure_touch_available(logger, "eink")`.
+- [ ] Cover derived-target behavior: when called without `target`, it should read live mode via `get_display_state(display_mgr)` and map `mode` to `eink` or `oled`.
+- [ ] Cover skip behavior: when live mode is `mixed` or `unknown`, it should not call `ensure_touch_available(...)`.
+- [ ] Cover logging behavior: include the reconciliation `reason` in logs for success/skip/failure paths.
+- [ ] Run: `python -m unittest tests.test_mode_switch_input_mode -v`
+- [ ] Verify the new tests fail because the reconciler does not exist yet.
+- [ ] Implement the minimal reconciler in `mode_switch.py`.
+- [ ] Keep `ensure_touch_available(...)` as the low-level retry helper; do not duplicate xinput logic.
+- [ ] Return a small, simple result contract that callers can use consistently (for example: `True` for healthy/recovered, `False` for failed or skipped), and document it with the function behavior/tests.
+- [ ] Re-run: `python -m unittest tests.test_mode_switch_input_mode -v`
+- [ ] Confirm the test module passes.
+
+### Task 2: Replace switch-path touch policy with the shared reconciler
+
+**Files:**
+- Modify: `mode_switch.py`
+- Modify: `tests/test_mode_switch_rotation.py`
+
+**Checklist:**
+- [ ] Add failing tests proving `switch_to_eink(...)` calls the shared reconciler once after successful input remap/orientation work.
+- [ ] Add failing tests proving `switch_to_oled(...)` calls the shared reconciler once after successful input remap/orientation work.
+- [ ] Assert these switch paths pass an explicit target (`"eink"` or `"oled"`) plus a useful reason string.
+- [ ] Assert recovery remains warning-only so a successful switch still returns success even if touch recovery fails.
+- [ ] Run: `python -m unittest tests.test_mode_switch_rotation -v`
+- [ ] Verify the new tests fail before implementation.
+- [ ] Update `switch_to_eink(...)` to call the shared reconciler instead of calling `ensure_touch_available(...)` directly.
+- [ ] Update `switch_to_oled(...)` the same way.
+- [ ] Preserve existing ordering around `_apply_input_mode(...)` and `apply_stored_orientation(...)`.
+- [ ] Re-run: `python -m unittest tests.test_mode_switch_rotation -v`
+- [ ] Confirm the switch-flow tests pass.
+
+### Task 3: Replace GUI orientation/lid touch policy with the shared reconciler
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+**Checklist:**
+- [ ] Add failing GUI tests proving `on_orientation_toggled(...)` calls the shared reconciler rather than directly calling `ensure_touch_available(...)`.
+- [ ] Verify the orientation path still re-applies `_apply_input_mode(...)` first, then runs reconciliation.
+- [ ] Add failing GUI tests proving `_reconcile_from_live_state(...)` uses the same shared reconciler for the lid-driven E-Ink rotation path.
+- [ ] Run: `python -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Verify the new tests fail before implementation.
+- [ ] Update `on_orientation_toggled(...)` to route touch recovery through the shared reconciler.
+- [ ] Update `_reconcile_from_live_state(...)` to route touch recovery through the shared reconciler.
+- [ ] Remove now-redundant direct `ensure_touch_available(...)` policy calls from GUI logic.
+- [ ] Re-run: `python -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Confirm the GUI state tests pass.
+
+### Task 4: Add debounced window-activation touch reconciliation for both windows
+
+**Files:**
+- Modify: `Tinta4Plus.py`
+- Modify: `tests/test_tinta4plus_ui_state.py`
+
+**Checklist:**
+- [ ] Add failing tests for a shared GUI activation handler that triggers touch reconciliation when the main window becomes active.
+- [ ] Add failing tests for the same behavior when the floating refresh button window becomes active.
+- [ ] Add failing tests proving activation derives the current target from live display state rather than forcing `eink` or `oled`.
+- [ ] Add failing tests proving `mixed`/`unknown` modes are skipped cleanly.
+- [ ] Add failing tests for debounce/throttle behavior so rapid duplicate focus events do not spam repeated reconciliations.
+- [ ] Run: `python -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Verify the activation tests fail before implementation.
+- [ ] Add a single GUI helper in `Tinta4Plus.py` for activation-triggered touch reconciliation.
+- [ ] Bind the main `root` window to that helper on activation/focus.
+- [ ] Bind the floating refresh button `Toplevel` window to that same helper when it is created.
+- [ ] Keep the floating button binding lifecycle-safe so destroyed/recreated windows do not leave stale references.
+- [ ] Implement a short debounce in the GUI helper so focus changes between widgets/windows do not trigger repeated xinput checks.
+- [ ] Re-run: `python -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Confirm the activation tests pass.
+
+### Task 5: Clean up imports/call sites and verify only one policy path remains
+
+**Files:**
+- Modify: `mode_switch.py`
+- Modify: `Tinta4Plus.py`
+- Verify: `tests/test_mode_switch_input_mode.py`
+- Verify: `tests/test_mode_switch_rotation.py`
+- Verify: `tests/test_tinta4plus_ui_state.py`
+
+**Checklist:**
+- [ ] Review `Tinta4Plus.py` imports and replace any stale direct `ensure_touch_available` usage with the shared reconciler where appropriate.
+- [ ] Review `mode_switch.py` and confirm there is one canonical policy entry point for touch reconciliation.
+- [ ] Confirm low-level helpers remain DRY: `_apply_input_mode(...)`, `_is_touch_healthy_for_target(...)`, `ensure_touch_available(...)`, and the new reconciler each have a distinct responsibility.
+- [ ] Run: `rg -n "ensure_touch_available|reconcile_touch|_apply_input_mode" Tinta4Plus.py mode_switch.py tests`
+- [ ] Inspect the output and confirm policy decisions are centralized rather than duplicated.
+
+### Task 6: Focused verification
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `Tinta4Plus.py`
+- Verify: `tests/test_mode_switch_input_mode.py`
+- Verify: `tests/test_mode_switch_rotation.py`
+- Verify: `tests/test_tinta4plus_ui_state.py`
+
+**Checklist:**
+- [ ] Run the focused automated tests:
+```bash
+python -m unittest \
+  tests.test_mode_switch_input_mode \
+  tests.test_mode_switch_rotation \
+  tests.test_tinta4plus_ui_state -v
+```
+- [ ] Confirm all focused tests pass.
+- [ ] Review the final diff:
+```bash
+git diff -- mode_switch.py Tinta4Plus.py tests/test_mode_switch_input_mode.py tests/test_mode_switch_rotation.py tests/test_tinta4plus_ui_state.py docs/plans/2026-04-04-unified-touch-reconcile-on-activation.md
+```
+- [ ] Confirm the diff contains only the shared touch reconciler refactor, activation hook, debounce logic, and regression tests.
+- [ ] If everything looks correct, hand off to implementation using `superpowers:executing-plans`.

--- a/docs/plans/2026-04-04-xfce-style-scaling-cleanup.md
+++ b/docs/plans/2026-04-04-xfce-style-scaling-cleanup.md
@@ -1,0 +1,161 @@
+# XFCE-Style Scaling Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace all active xrandr scaling code with XFCE-style transform-based scaling for both OLED and E-Ink, and remove the temporary `1.0 -> target` reset hack entirely.
+
+**Architecture:** Keep scaling centralized in `DisplayManager.py` so GUI and CLI mode-switch flows continue to delegate to one implementation. Preserve the current target-state/verification structure, but change it to generate XFCE-style `--transform` commands instead of `--scale`, and remove all active-code/test leftovers tied to the old lower-scale reset workaround.
+
+**Tech Stack:** Python 3, X11/XRandR (`xrandr`), existing `DisplayManager`, `mode_switch.py`, `unittest`, `unittest.mock`
+
+---
+
+## Task 1: Add failing tests for XFCE-style transform scaling
+
+**Files:**
+- Modify: `tests/test_display_manager_rotation.py`
+- Verify: `DisplayManager.py`
+
+- [ ] Add a failing test proving `_apply_display_scale("eDP-1", scale=1.5)` generates an `xrandr` command with:
+  - `--mode 2880x1800`
+  - `--transform 0.6666666666666666,0,0,0,0.6666666666666666,0,0,0,1`
+  - `--panning 1920x1200`
+  - `--fb 1920x1200`
+  - and **does not** include `--scale`
+- [ ] Add a failing test proving `finalize_single_display("eDP-2", scale=1.75)` generates an `xrandr` command with:
+  - `--mode 2560x1600`
+  - `--transform 0.5714285714285714,0,0,0,0.5714285714285714,0,0,0,1`
+  - `--panning 1463x915`
+  - `--fb 1463x915`
+  - and **does not** include `--scale`
+- [ ] Add a failing test proving `enable_display("eDP-1", scale=1.5)` uses transform-based activation and does **not** include `--fb`
+- [ ] Update any existing command-shape tests that still assert `--scale`
+- [ ] Remove or rewrite tests whose only purpose is to verify the `1.0 -> target` reset workaround
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm the failures are specifically about command generation still using `--scale` or reset-hack assumptions
+
+## Task 2: Refactor target-state generation to describe transform scaling clearly
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Inspect `_build_display_target_state(display_name, scale=None)` and identify all fields that still imply old `--scale` semantics
+- [ ] Replace those active-code field names with transform-oriented names, or add new transform-oriented fields and delete obsolete ones
+- [ ] Keep the requested scale semantics unchanged:
+  - app scale `1.0` means native/unscaled
+  - app scale `> 1.0` means larger UI / smaller logical desktop
+- [ ] Keep logical dimension math based on native size divided by requested scale, rounded up with `math.ceil(...)`
+- [ ] Store enough target-state data to build XFCE-style transforms deterministically for both outputs
+- [ ] Update target-state tests so they assert the transform coefficients and logical dimensions, not `xrandr_scale_x/y`
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation.DisplayManagerScalingTests -v
+  ```
+- [ ] Confirm the target-state tests pass before moving on
+
+## Task 3: Replace all active `--scale` command generation with XFCE-style `--transform`
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Test: `tests/test_display_manager_rotation.py`
+
+- [ ] Update `_apply_display_target_state(target_state)` to build:
+  ```bash
+  xrandr --output <display> --mode <native> --transform <a,0,0,0,a,0,0,0,1> --panning <logical> --fb <logical>
+  ```
+- [ ] For native/unscaled state, ensure the transform is the identity matrix:
+  - `--transform 1,0,0,0,1,0,0,0,1`
+- [ ] Update `_apply_display_scale(display_name, scale=None)` to use the new target-state fields without any `--scale` fallback for known displays
+- [ ] Update `_activate_display_transition_safe(display_name, scale=None)` to use `--transform` and `--mode`, and to omit `--fb` intentionally
+- [ ] Keep unknown-display fallback behavior as `xrandr --output <display> --auto`
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm all command-generation tests now pass with `--transform`
+- [ ] Commit:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py
+  git commit -m "refactor(display): use xfce-style transform scaling"
+  ```
+
+## Task 4: Remove the lower-scale reset hack and any active-code leftovers
+
+**Files:**
+- Modify: `DisplayManager.py`
+- Modify: `tests/test_display_manager_rotation.py`
+- Verify: `docs/plans/2026-04-04-lower-scale-reset-on-target-display.md`
+
+- [ ] Remove any helper whose only job is resetting the target display to native before retry
+- [ ] Remove any `enable_display()` orchestration that applies `1.0` before the requested target scale
+- [ ] Remove dead parsing/branching that exists only to support the reset workaround if it is no longer needed
+- [ ] Delete or rewrite tests that expect multiple applies when lowering scale
+- [ ] Leave historical plan docs untouched unless asked; do **not** treat them as runtime leftovers
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_display_manager_rotation -v
+  ```
+- [ ] Confirm no active code or tests still enforce the reset hack
+- [ ] Commit:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py
+  git commit -m "fix(display): remove lower-scale reset hack"
+  ```
+
+## Task 5: Verify shared OLED and E-Ink switching paths still inherit the cleanup
+
+**Files:**
+- Verify: `mode_switch.py`
+- Verify: `toggle-eink.py`
+- Verify: `Tinta4Plus.py`
+- Test: `tests/test_mode_switch_state.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+- [ ] Confirm shared switch paths still call `display_mgr.enable_display(..., scale=scale)` and `display_mgr.finalize_single_display(..., scale=scale)`
+- [ ] Confirm no GUI or CLI path duplicates low-level transform logic outside `DisplayManager.py`
+- [ ] Add or update only light regression coverage if needed to prove shared flows still pass the configured scale through unchanged
+- [ ] Run:
+  ```bash
+  python -m unittest tests.test_mode_switch_state tests.test_mode_switch_rotation -v
+  ```
+- [ ] Confirm shared-flow tests pass without needing any reset-specific logic
+
+## Task 6: Final verification before claiming cleanup is complete
+
+**Files:**
+- Verify: `DisplayManager.py`
+- Verify: `tests/test_display_manager_rotation.py`
+- Verify: `tests/test_mode_switch_state.py`
+- Verify: `tests/test_mode_switch_rotation.py`
+
+- [ ] Run the full relevant automated suite:
+  ```bash
+  python -m unittest \
+    tests.test_display_manager_rotation \
+    tests.test_mode_switch_state \
+    tests.test_mode_switch_rotation \
+    tests.test_tinta4plus_ui_state -v
+  ```
+- [ ] Review the final active-code diff:
+  ```bash
+  git diff -- DisplayManager.py tests/test_display_manager_rotation.py tests/test_mode_switch_state.py tests/test_mode_switch_rotation.py
+  ```
+- [ ] Confirm active code and tests contain:
+  - one transform-based scaling model
+  - no `--scale` assertions for known-display scaling paths
+  - no `1.0 -> target` reset orchestration
+  - no misleading helper names/comments in active code
+- [ ] Manually verify on hardware:
+  - switch to OLED with non-1.0 scaling
+  - switch to E-Ink with non-1.0 scaling
+  - lower scale and raise scale without clipping
+  - confirm behavior matches the `fix-oled.sh` model
+- [ ] Commit final verified state if needed:
+  ```bash
+  git add DisplayManager.py tests/test_display_manager_rotation.py tests/test_mode_switch_state.py tests/test_mode_switch_rotation.py
+  git commit -m "fix(display): unify scaling around xfce-style transforms"
+  ```

--- a/docs/plans/2026-04-05-display-roundtrip-reliability.md
+++ b/docs/plans/2026-04-05-display-roundtrip-reliability.md
@@ -1,0 +1,360 @@
+# Display Roundtrip Reliability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make one OLED ↔ E-Ink roundtrip reliable by refactoring mode-switch orchestration around an explicit critical display-convergence phase, while treating theme, DPMS, input, touch, and stored-orientation work as best-effort follow-up after convergence succeeds.
+
+**Architecture:** Keep all low-level RandR target-state math and verification in `DisplayManager.py`, where `_build_display_target_state(...)`, activation, and final verification already live. Refactor `mode_switch.py` so each switch path is split into explicit phases: preparation, critical single-display convergence, best-effort post-success reconciliation, and must-run cleanup. Add one shared orchestration helper that converges to a single active display by calling existing `DisplayManager` primitives in a deterministic order and emitting useful mismatch diagnostics on failure.
+
+**Tech Stack:** Python 3, `xrandr`, `subprocess`, `unittest`, `unittest.mock`.
+
+---
+
+## Scope Checklist
+
+- [ ] Prioritize reliable display roundtrip over preserving every current side-effect ordering
+- [ ] Keep helper protocol unchanged
+- [ ] Keep GUI/CLI entrypoints unchanged
+- [ ] Keep low-level display target-state construction in `DisplayManager.py`
+- [ ] Refactor only mode-switch orchestration in `mode_switch.py`
+- [ ] Make theme switching best-effort after display convergence succeeds
+- [ ] Make input/touch/orientation reconciliation best-effort after display convergence succeeds
+- [ ] Treat DPMS save/restore as best-effort post-success reconciliation
+- [ ] Add regression tests for one successful OLED → E-Ink → OLED logical roundtrip flow
+- [ ] Add tests for early failure when target display state does not converge
+
+## Design Checklist
+
+- [ ] Structure each switch flow into explicit phases
+  - [ ] Phase 1: helper/hardware preparation
+  - [ ] Phase 2: critical display convergence
+  - [ ] Phase 3: best-effort post-success follow-up actions
+  - [ ] Phase 4: must-run cleanup/final logging
+- [ ] Give each phase its own `try/except` boundary
+- [ ] Use `finally` for cleanup that must run regardless of success/failure
+  - [ ] terminate privacy image process
+  - [ ] release temporary state/resources
+  - [ ] emit guarded end-of-switch diagnostics
+- [ ] Ensure critical-phase failure returns switch failure immediately
+- [ ] Ensure best-effort follow-up failures are warning-only and do not override convergence result
+- [ ] Define one orchestration-level target description for `oled`
+  - [ ] target output = `eDP-1`
+  - [ ] other output = `eDP-2`
+  - [ ] follow-up theme = `Adwaita-dark`
+  - [ ] follow-up input/touch target = `oled`
+  - [ ] snapshot reason = `switch_to_oled`
+- [ ] Define one orchestration-level target description for `eink`
+  - [ ] target output = `eDP-2`
+  - [ ] other output = `eDP-1`
+  - [ ] follow-up theme = `HighContrast`
+  - [ ] follow-up input/touch target = `eink`
+  - [ ] snapshot reason = `switch_to_eink`
+- [ ] Define one deterministic convergence order for both targets
+  - [ ] enable target output in transition-safe mode
+  - [ ] disable non-target output
+  - [ ] finalize compact single-display layout
+  - [ ] fail fast if final verification does not converge
+- [ ] Separate critical steps from non-critical steps
+  - [ ] critical = display topology/scaling convergence via `DisplayManager`
+  - [ ] non-critical = theme, DPMS, touch/input, stored orientation, frontlight polish
+- [ ] Preserve ownership boundaries
+  - [ ] `DisplayManager.py` owns low-level RandR state math and verification
+  - [ ] `mode_switch.py` owns helper sequencing, follow-up policies, and cleanup
+
+## Task 1: Add failing switch-ordering tests
+
+**Files:**
+- Modify: `tests/test_mode_switch_rotation.py`
+- Modify: `tests/test_mode_switch_state.py` only if a shared helper contract belongs there
+
+**Step 1: Write a failing test for OLED post-convergence ordering**
+
+Add a test proving `switch_to_oled(...)` only runs best-effort follow-up work after critical display convergence succeeds.
+
+Example assertions:
+- critical display calls complete first
+- theme/DPMS/input/orientation/touch hooks run only after convergence success
+- if convergence fails, function returns `False`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: FAIL because current flow still changes theme before convergence is proven.
+
+**Step 3: Write a failing test for E-Ink post-convergence ordering**
+
+Add the symmetric test for `switch_to_eink(...)`.
+
+**Step 4: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: FAIL for the same reason.
+
+**Step 5: Commit the tests**
+
+```bash
+git add tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py
+git commit -m "test(display): cover post-converge switch ordering"
+```
+
+## Task 2: Add orchestration-level target helper(s)
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_state.py`
+
+**Step 1: Write a failing test for orchestration target metadata**
+
+Add tests for a helper such as `_build_switch_target(mode)` asserting exact fields for:
+- mode name
+- target output name
+- other output name
+- theme name
+- touch/input target name
+- snapshot/logging reason
+
+Do **not** duplicate low-level transform/framebuffer math here.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_state.py`
+Expected: FAIL because helper does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a small helper returning orchestration metadata for `oled` and `eink`, derived from existing constants in `mode_switch.py`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_state.py`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_state.py
+git commit -m "refactor(display): add switch target metadata"
+```
+
+## Task 3: Centralize critical single-display convergence
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+**Step 1: Write a failing test for a shared convergence helper**
+
+Add tests for a helper such as `_converge_single_display(display_mgr, logger, switch_target, scale)` proving it:
+- enables the target output with `display_mgr.enable_display(...)`
+- disables the non-target output with `display_mgr.disable_display(...)`
+- finalizes the compact single-display layout with `display_mgr.finalize_single_display(...)`
+- returns `False` if any critical step fails
+- does not run any non-critical follow-up work itself
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: FAIL because helper does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Extract the critical display-only path from both switch functions into the shared convergence helper. Keep all target-state math delegated to `DisplayManager.py`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py
+git commit -m "refactor(display): centralize single-display convergence"
+```
+
+## Task 4: Refactor OLED switch into explicit phases
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+**Step 1: Write a failing test for OLED convergence failure behavior**
+
+Add a test proving that when critical convergence fails:
+- `switch_to_oled(...)` returns `False`
+- non-critical follow-up actions do not run
+- success logging does not run
+- privacy image cleanup still runs
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: FAIL under current structure.
+
+**Step 3: Write minimal implementation**
+
+Refactor `switch_to_oled(...)` into explicit phases:
+1. helper/hardware preparation in its own `try/except`
+2. critical convergence helper call in its own `try/except`
+3. best-effort follow-up phase in its own `try/except`
+4. must-run cleanup in `finally`
+
+OLED policy:
+- preparation may start privacy image, disable E-Ink in helper, and disable frontlight
+- critical convergence failure returns `False`
+- follow-up phase handles dark theme, DPMS restore, input mode, stored orientation, touch reconcile, snapshot logging
+- privacy image teardown must happen in `finally`
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py
+git commit -m "refactor(display): gate oled follow-ups on convergence"
+```
+
+## Task 5: Refactor E-Ink switch into explicit phases
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+**Step 1: Write a failing test for E-Ink convergence failure behavior**
+
+Add a test proving that when critical convergence fails:
+- `switch_to_eink(...)` returns `False`
+- follow-up actions do not run after failed convergence
+- success logging does not run
+- no false-positive theme/DPMS post-success state is applied
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Refactor `switch_to_eink(...)` to mirror the OLED structure:
+1. helper/hardware preparation in its own `try/except`
+2. critical convergence helper call in its own `try/except`
+3. best-effort follow-up phase in its own `try/except`
+4. must-run cleanup/logging in `finally`
+
+E-Ink policy:
+- preparation may enable helper E-Ink mode and optionally set frontlight brightness
+- critical convergence failure returns `False`
+- follow-up phase handles HighContrast theme, DPMS disable, input mode, stored orientation, touch reconcile, snapshot logging
+- no early return may skip guarded final diagnostics
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py
+git commit -m "refactor(display): gate eink follow-ups on convergence"
+```
+
+## Task 6: Tighten convergence failure logging
+
+**Files:**
+- Modify: `mode_switch.py`
+- Test: `tests/test_mode_switch_rotation.py`
+
+**Step 1: Write a failing test for convergence failure logging**
+
+Add a test proving critical convergence failure logs:
+- target mode (`oled` or `eink`)
+- expected target output
+- expected non-target output
+- which critical step failed (`enable`, `disable`, or `finalize`)
+
+If available from existing logs, include mismatch payload emitted by `DisplayManager` verification instead of recreating it in `mode_switch.py`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Improve failure logging in the shared convergence helper so switch-level diagnostics clearly identify the intended target and failed step while preserving `DisplayManager` as the owner of low-level mismatch details.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest -q tests/test_mode_switch_rotation.py`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py
+git commit -m "chore(display): log convergence failure context"
+```
+
+## Task 7: End-to-end regression verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run focused unit tests**
+
+Run:
+```bash
+python3 -m unittest -q \
+  tests/test_mode_switch_rotation.py \
+  tests/test_mode_switch_state.py \
+  tests/test_tinta4plus_ui_state.py \
+  tests/test_logging_targets.py
+```
+Expected: PASS.
+
+**Step 2: Run one real CLI roundtrip**
+
+Run:
+```bash
+python3 toggle-eink.py
+python3 toggle-eink.py
+```
+Expected:
+- first command switches to E-Ink or fails with explicit convergence diagnostics
+- second command restores OLED without leaving HighContrast behind
+- final `xrandr --query` shows only the intended target display active
+
+**Step 3: Capture final live state**
+
+Run:
+```bash
+xrandr --query
+xrandr --listactivemonitors
+xfconf-query -c xsettings -p /Net/ThemeName
+```
+Expected:
+- OLED target: only `eDP-1` active, dark theme
+- E-Ink target: only `eDP-2` active, HighContrast theme
+
+**Step 4: Commit final refactor**
+
+```bash
+git add mode_switch.py tests/test_mode_switch_rotation.py tests/test_mode_switch_state.py
+git commit -m "refactor(display): converge roundtrip switching reliably"
+```
+
+## Success Criteria Checklist
+
+- [ ] A single OLED → E-Ink → OLED roundtrip works reliably
+- [ ] Each switch path is structured as explicit phases with separate error handling
+- [ ] Must-run cleanup executes via `finally` even when switch phases fail
+- [ ] Theme no longer remains HighContrast on OLED after failed or partial OLED return path
+- [ ] Switch functions do not report success when target display state failed to converge
+- [ ] Critical display convergence is isolated from best-effort follow-up work
+- [ ] `DisplayManager.py` remains the sole owner of low-level target-state math and verification
+- [ ] Unit tests cover convergence success/failure ordering
+- [ ] Live verification confirms final display and theme state after roundtrip

--- a/docs/plans/2026-04-05-eink-live-state-reconcile.md
+++ b/docs/plans/2026-04-05-eink-live-state-reconcile.md
@@ -1,0 +1,128 @@
+# E-Ink Live State Reconcile Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make every E-Ink-related trigger converge through one reconciler that ensures touch health, lid-close sleep inhibitor state, orientation policy, and UI state from live facts.
+
+**Architecture:** Treat startup, reconnect, mode switches, lid/RandR invalidations, and window activation as dumb triggers that only request a live-state reconcile. Keep `Tinta4Plus.py` as the sole policy owner. `_reconcile_from_live_state()` should read the live facts, derive the desired E-Ink policy, apply only the minimal changes needed, and remain safe to call repeatedly.
+
+**Tech Stack:** Python 3, tkinter, unittest, `systemd-inhibit`, existing `mode_switch.py` touch helpers.
+
+---
+
+## Reductionist state-machine policy
+
+### Live facts the reconciler reads
+- display mode: `oled | eink | mixed | unknown`
+- lid state: `open | closed`
+- active display and current rotation
+- current inhibitor process status
+
+### Desired policy derived from those facts
+- If live mode is `eink`:
+  - lid-close inhibitor must be running
+  - E-Ink orientation must match lid policy
+    - lid open -> landscape (`normal`)
+    - lid closed -> portrait (`left`)
+  - E-Ink touch must be usable after any needed orientation or mode correction
+- If live mode is not `eink`:
+  - lid-close inhibitor must not be running
+  - no E-Ink-specific rotation or touch enforcement should run
+
+### Trigger rule
+The following code paths must not own policy. They should only request reconcile:
+- helper startup success
+- helper reconnect success
+- successful mode switch
+- lid invalidation
+- RandR invalidation
+- window activation/focus events
+
+### Code comments requirement
+Add a short comment block above `_reconcile_from_live_state()` explaining:
+1. it is the single policy owner for live E-Ink usability
+2. all triggers should feed into it rather than duplicating touch/inhibitor policy elsewhere
+3. it is intentionally idempotent and may be called often
+
+---
+
+## Checklist
+
+### Task 1: Add failing orchestration tests for the single-reconciler design
+- [ ] Modify `tests/test_tinta4plus_ui_state.py`
+- [ ] Add a failing test proving `initialize_helper()` requests `_reconcile_from_live_state()` immediately after successful helper connection
+- [ ] Add a failing test proving `attempt_helper_restart()` requests `_reconcile_from_live_state()` immediately after successful reconnect
+- [ ] Add a failing test proving successful `on_eink_toggled()` -> `switch_to_eink(...)` requests `_reconcile_from_live_state()`
+- [ ] Add a failing test proving window activation requests `_reconcile_from_live_state()` instead of directly owning E-Ink touch policy
+- [ ] Add/adjust tests so non-E-Ink activation remains a no-op or cheap no-op through the reconciler rather than separate policy branches
+- [ ] Run `python3 -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Verify the new tests fail for the expected orchestration reason
+
+**Notes:**
+- Prefer orchestration assertions with mocks over deep implementation coupling.
+- Keep tests focused on “who owns policy” rather than incidental UI details.
+
+### Task 2: Make all relevant triggers request the reconciler and nothing else
+- [ ] Modify `Tinta4Plus.py`
+- [ ] In `initialize_helper()`, after successful helper connection and watcher setup, call `_reconcile_from_live_state()`
+- [ ] In `attempt_helper_restart()`, after successful reconnect and watcher setup, call `_reconcile_from_live_state()`
+- [ ] In `on_eink_toggled()`, after successful `switch_to_eink(...)`, call `_reconcile_from_live_state()`
+- [ ] In `_on_window_activated()`, replace direct touch-policy ownership with a reconcile request after debounce
+- [ ] Ensure trigger paths do not duplicate touch/inhibitor/orientation policy outside `_reconcile_from_live_state()`
+- [ ] Preserve existing error handling and `check_ec_status` scheduling
+- [ ] Run `python3 -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Verify the new trigger-orchestration tests pass
+
+**Notes:**
+- A trigger may still do trigger-local bookkeeping like debounce.
+- A trigger should not decide whether touch or inhibitor work is needed.
+
+### Task 3: Simplify and document the reconciler as the single policy owner
+- [ ] Modify `Tinta4Plus.py`
+- [ ] Add the explanatory comment block above `_reconcile_from_live_state()` describing the reconciler policy
+- [ ] Review `_reconcile_from_live_state()` and keep policy decisions centralized there:
+  - [ ] read live display mode
+  - [ ] read live lid state
+  - [ ] ensure inhibitor state matches live mode
+  - [ ] ensure E-Ink rotation matches lid state when in E-Ink mode
+  - [ ] ensure touch recovery/remap happens only from reconciler-owned E-Ink decisions
+  - [ ] update remembered `_live_sync_state`
+  - [ ] sync UI from live state
+- [ ] Keep reconciler idempotent: no duplicate inhibitor spawns, no unnecessary rotation, no unnecessary touch work
+- [ ] Run `python3 -m unittest tests.test_tinta4plus_ui_state -v`
+- [ ] Verify existing reconciler lifecycle/orientation tests still pass
+
+**Notes:**
+- Do not introduce a second policy function unless the existing reconciler becomes impossible to reason about.
+- Prefer reducing branches over adding new special-case helpers.
+
+### Task 4: Strengthen regression tests around the state machine
+- [ ] Modify `tests/test_tinta4plus_ui_state.py` only if needed for coverage gaps
+- [ ] Ensure tests cover:
+  - [ ] no duplicate inhibitor process creation
+  - [ ] lid-driven E-Ink rotation remains correct
+  - [ ] duplicate invalidations with no effective state change stay cheap
+  - [ ] window activation debounce still works
+  - [ ] non-E-Ink modes do not perform E-Ink-only side effects
+- [ ] Add brief test comments where intent is non-obvious, especially around “trigger vs policy owner” expectations
+- [ ] Run:
+```bash
+python3 -m unittest \
+  tests.test_tinta4plus_ui_state \
+  tests.test_mode_switch_input_mode \
+  tests.test_mode_switch_state \
+  -v
+```
+- [ ] Verify PASS with no new failures
+
+### Task 5: Final verification and review of simplification
+- [ ] Inspect the final diff:
+```bash
+git diff -- Tinta4Plus.py tests/test_tinta4plus_ui_state.py docs/plans/2026-04-05-eink-live-state-reconcile.md
+```
+- [ ] Confirm policy is simpler than before:
+  - [ ] triggers only request reconcile
+  - [ ] reconciler owns E-Ink usability policy
+  - [ ] comments explain why
+  - [ ] tests lock the state-machine shape
+- [ ] If the diff still shows trigger-specific policy branching, simplify before finishing

--- a/docs/plans/2026-05-18-disable-eink-output-user-unit.md
+++ b/docs/plans/2026-05-18-disable-eink-output-user-unit.md
@@ -1,0 +1,31 @@
+# Disable E-Ink Output User Unit Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Install and update a systemd user unit that runs `xrandr` at login to disable the E-Ink X11 output and keep OLED primary.
+**Architecture:** Add a repo-tracked user unit and let the GUI install/check it in the current user's systemd user config. Keep privileged helper installation unchanged.
+**Tech Stack:** Python/Tkinter GUI, systemd --user, xrandr, shell subprocesses.
+
+---
+
+- [ ] Task 1: Add tracked user unit
+  - Files: `contrib/systemd/user/tinta4plus-disable-eink-output.service`
+  - Change: Create a oneshot unit with an `ExecStart=/usr/bin/xrandr --output eDP-2 --off --output eDP-1 --auto --primary` and a comment explaining X11 `DISPLAY`/`XAUTHORITY` requirements.
+  - Verify: `systemd-analyze --user verify contrib/systemd/user/tinta4plus-disable-eink-output.service`
+
+- [ ] Task 2: Extend GUI drift check
+  - Files: `Tinta4Plus.py`
+  - Test first: add/modify a unit test if existing install-check tests exist; otherwise manually verify with `python3 -m py_compile Tinta4Plus.py`.
+  - Implement: Add helpers to compare the repo user unit with `~/.config/systemd/user/tinta4plus-disable-eink-output.service` and check `systemctl --user is-enabled tinta4plus-disable-eink-output.service`.
+  - Verify: `python3 -m py_compile Tinta4Plus.py`
+
+- [ ] Task 3: Install/enable user unit with --now
+  - Files: `Tinta4Plus.py`
+  - Implement: After successful root helper install, copy the user unit to `~/.config/systemd/user/`, run `systemctl --user daemon-reload`, then `systemctl --user enable --now tinta4plus-disable-eink-output.service`.
+  - Verify: `python3 -m py_compile Tinta4Plus.py`
+  - Manual check: `systemctl --user status tinta4plus-disable-eink-output.service --no-pager`
+
+- [ ] Task 4: End-to-end verification
+  - Run: `python3 -m pytest tests` if pytest is available.
+  - Run: GUI installer flow or helper methods manually if GUI automation is impractical.
+  - Check: user unit is enabled and current display layout has `eDP-2` off after the `--now` start.

--- a/docs/plans/2026-06-18-display-power-policy.md
+++ b/docs/plans/2026-06-18-display-power-policy.md
@@ -1,0 +1,36 @@
+# Display Power Policy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve OLED display power-management settings, disable all display blanking while on E-Ink, and restore OLED settings when switching back.
+**Architecture:** Replace the narrow DPMS snapshot with a broader display power policy snapshot covering xset screensaver/DPMS and XFCE power-manager keys. Keep existing switch call sites so GUI/CLI behavior remains unchanged.
+**Tech Stack:** Python, unittest, subprocess-backed X11/XFCE commands.
+
+---
+
+- [x] Task 1: Add xset screensaver capture/restore tests
+  - Files: `tests/test_mode_switch_power_policy.py`, `mode_switch.py`
+  - Test first: parse `xset q` output with Screen Saver and DPMS sections.
+  - Verify RED: `python3 -m unittest tests.test_mode_switch_power_policy` should fail because helpers do not exist / screensaver is not captured.
+  - Implement: capture `screensaver_timeout`, `screensaver_cycle`, DPMS enabled/timeouts in a unified state.
+  - Verify GREEN: `python3 -m unittest tests.test_mode_switch_power_policy`
+
+- [x] Task 2: Add XFCE power-manager snapshot/apply/restore tests
+  - Files: `tests/test_mode_switch_power_policy.py`, `mode_switch.py`
+  - Test first: fake `xfconf-query` get/set calls for blanking and DPMS keys.
+  - Verify RED: command expectations fail because XFCE state is not handled.
+  - Implement: query configured XFCE keys, save present values with type metadata, set E-Ink policy values, restore saved values.
+  - Verify GREEN: `python3 -m unittest tests.test_mode_switch_power_policy`
+
+- [x] Task 3: Integrate with existing mode switching and compatibility
+  - Files: `mode_switch.py`, existing tests
+  - Test first: ensure existing `_disable_dpms_for_eink` and `_restore_dpms_after_eink` use the broader policy and do not overwrite an existing snapshot.
+  - Verify RED: focused unittest should fail under old behavior.
+  - Implement: keep function names as compatibility wrappers; add legacy `dpms_saved_state` restore fallback.
+  - Verify GREEN: `python3 -m unittest tests.test_mode_switch_power_policy tests.test_mode_switch_rotation tests.test_mode_switch_state`
+
+- [x] Task 4: Full verification and commit
+  - Files: all touched files only.
+  - Verify: `python3 -m unittest discover tests`
+  - Review: `git diff -- mode_switch.py tests/test_mode_switch_power_policy.py docs/plans/2026-06-18-display-power-policy.md`
+  - Commit: stage only intended files and commit with Conventional Commit subject.

--- a/event_watcher.py
+++ b/event_watcher.py
@@ -1,0 +1,41 @@
+"""Background event watcher helpers for lid + RandR invalidations."""
+
+from __future__ import annotations
+
+import time
+
+
+def _safe_send(send_message, payload):
+    try:
+        send_message(payload)
+    except Exception:
+        # Parent may have exited.
+        pass
+
+
+def send_lid_invalidation(send_message):
+    _safe_send(send_message, ("lid", None))
+
+
+def send_randr_invalidation(send_message):
+    _safe_send(send_message, ("randr", None))
+
+
+def send_error(send_message, message):
+    _safe_send(send_message, ("error", str(message)))
+
+
+def watch_events(send_conn):
+    """Process entrypoint.
+
+    Real lid/RandR subscriptions will push invalidations through this single channel.
+    For now this loop keeps the worker process alive until the parent terminates it.
+    """
+
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        return
+    except Exception as exc:
+        send_error(send_conn.send, exc)

--- a/event_watcher.py
+++ b/event_watcher.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
 import time
+
+
+LID_STATE_PATHS = (
+    "/proc/acpi/button/lid/LID0/state",
+    "/proc/acpi/button/lid/LID/state",
+)
 
 
 def _safe_send(send_message, payload):
@@ -25,17 +32,61 @@ def send_error(send_message, message):
     _safe_send(send_message, ("error", str(message)))
 
 
-def watch_events(send_conn):
-    """Process entrypoint.
+def _read_lid_state():
+    for path in LID_STATE_PATHS:
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                text = handle.read().lower()
+            if "closed" in text:
+                return True
+            if "open" in text:
+                return False
+        except FileNotFoundError:
+            continue
+        except Exception:
+            return None
+    return None
 
-    Real lid/RandR subscriptions will push invalidations through this single channel.
-    For now this loop keeps the worker process alive until the parent terminates it.
-    """
+
+def _randr_fingerprint():
+    try:
+        output = subprocess.run(
+            ["xrandr", "--query"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except Exception:
+        return None
+
+    connected_lines = []
+    for line in output.splitlines():
+        if " connected" in line:
+            connected_lines.append(" ".join(line.split()))
+    return "\n".join(sorted(connected_lines))
+
+
+def watch_events(send_conn):
+    """Watch lid and display changes and emit invalidations on one channel."""
+
+    send_message = send_conn.send
+    last_lid_state = _read_lid_state()
+    last_randr = _randr_fingerprint()
 
     try:
         while True:
-            time.sleep(1.0)
+            time.sleep(0.5)
+
+            lid_state = _read_lid_state()
+            if lid_state is not None and lid_state != last_lid_state:
+                last_lid_state = lid_state
+                send_lid_invalidation(send_message)
+
+            randr = _randr_fingerprint()
+            if randr is not None and randr != last_randr:
+                last_randr = randr
+                send_randr_invalidation(send_message)
     except KeyboardInterrupt:
         return
     except Exception as exc:
-        send_error(send_conn.send, exc)
+        send_error(send_message, exc)

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -482,6 +482,23 @@ def _restore_dpms_after_eink(logger):
         logger.warning(f"Could not restore DPMS state: {e}")
 
 
+def _attempt_finalize_reconcile(display_mgr, logger, display_name, scale):
+    """Best-effort layout reconcile to keep active output usable after partial switch failures."""
+    try:
+        if display_mgr.finalize_single_display(display_name, scale=scale):
+            logger.warning(
+                f"Recovered {display_name} layout with best-effort finalize after transition failure"
+            )
+            return True
+        logger.warning(
+            f"Best-effort finalize failed for {display_name} after transition failure"
+        )
+        return False
+    except Exception as e:
+        logger.warning(f"Best-effort finalize raised for {display_name}: {e}")
+        return False
+
+
 def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, enable_frontlight=True, brightness_level=4):
     logger.info("Switching to E-Ink...")
 
@@ -508,6 +525,7 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     if not display_mgr.disable_display(DISPLAY_OLED):
         logger.error("Failed to disable OLED output")
+        _attempt_finalize_reconcile(display_mgr, logger, DISPLAY_EINK, scale)
         return False
 
     if not display_mgr.finalize_single_display(DISPLAY_EINK, scale=scale):
@@ -570,6 +588,7 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     if not display_mgr.disable_display(DISPLAY_EINK):
         logger.error("Failed to disable E-Ink output")
+        _attempt_finalize_reconcile(display_mgr, logger, DISPLAY_OLED, scale)
         return False
 
     if not display_mgr.finalize_single_display(DISPLAY_OLED, scale=scale):

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -24,6 +24,28 @@ SUPPORTED_ORIENTATION_ROTATIONS = {"normal", "left"}
 ORIENTATION_PREFERENCE_KEY = "orientation_preference"
 
 
+def _build_switch_target(mode):
+    if mode == "oled":
+        return {
+            "mode": "oled",
+            "target_output": DISPLAY_OLED,
+            "other_output": DISPLAY_EINK,
+            "theme": THEME_ADWAITA_DARK,
+            "input_target": "oled",
+            "snapshot_reason": "switch_to_oled",
+        }
+    if mode == "eink":
+        return {
+            "mode": "eink",
+            "target_output": DISPLAY_EINK,
+            "other_output": DISPLAY_OLED,
+            "theme": THEME_HIGH_CONTRAST,
+            "input_target": "eink",
+            "snapshot_reason": "switch_to_eink",
+        }
+    raise ValueError(f"Unsupported switch target mode: {mode}")
+
+
 def get_display_state(display_mgr):
     oled_active = display_mgr.is_display_active(DISPLAY_OLED)
     eink_active = display_mgr.is_display_active(DISPLAY_EINK)
@@ -299,6 +321,35 @@ def _apply_input_mode(logger, target):
     return success
 
 
+def _converge_single_display(display_mgr, logger, switch_target, scale):
+    mode = switch_target["mode"]
+    target_output = switch_target["target_output"]
+    other_output = switch_target["other_output"]
+
+    if not display_mgr.enable_display(target_output, scale=scale):
+        logger.error(
+            f"Display convergence failed for mode={mode} step=enable "
+            f"target_output={target_output} other_output={other_output}"
+        )
+        return False
+
+    if not display_mgr.disable_display(other_output):
+        logger.error(
+            f"Display convergence failed for mode={mode} step=disable "
+            f"target_output={target_output} other_output={other_output}"
+        )
+        return False
+
+    if not display_mgr.finalize_single_display(target_output, scale=scale):
+        logger.error(
+            f"Display convergence failed for mode={mode} step=finalize "
+            f"target_output={target_output} other_output={other_output}"
+        )
+        return False
+
+    return True
+
+
 def _resolve_privacy_image_path(script_dir):
     image_path = EINK_DISABLED_IMAGE
     if os.path.exists(image_path):
@@ -484,115 +535,120 @@ def _restore_dpms_after_eink(logger):
 
 def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, enable_frontlight=True, brightness_level=4):
     logger.info("Switching to E-Ink...")
+    switch_target = _build_switch_target("eink")
+    converged = False
 
-    _disable_dpms_for_eink(logger)
+    try:
+        if not helper_command(helper, logger, "enable-eink"):
+            return False
 
-    if autoswitch_theme:
-        set_xfce_theme(logger, THEME_HIGH_CONTRAST)
+        if enable_frontlight:
+            helper_command(helper, logger, "enable-frontlight", brightness_level=brightness_level)
 
-    if not display_mgr.enable_display(DISPLAY_EINK, scale=scale):
-        logger.error("Failed to enable E-Ink display output")
+        time.sleep(0.5)
+    except Exception as e:
+        logger.error(f"E-Ink preparation failed: {e}")
         return False
 
-    time.sleep(1.0)
-
-    if not helper_command(helper, logger, "enable-eink"):
-        logger.error("Rolling back: enabling OLED display")
-        display_mgr.enable_display(DISPLAY_OLED, scale=scale)
+    try:
+        converged = _converge_single_display(display_mgr, logger, switch_target, scale)
+        if not converged:
+            return False
+    except Exception as e:
+        logger.error(f"E-Ink display convergence failed: {e}")
         return False
 
-    if enable_frontlight:
-        helper_command(helper, logger, "enable-frontlight", brightness_level=brightness_level)
+    try:
+        _disable_dpms_for_eink(logger)
 
-    time.sleep(0.5)
+        if autoswitch_theme:
+            set_xfce_theme(logger, switch_target["theme"])
 
-    disable_ok = display_mgr.disable_display(DISPLAY_OLED)
-    if not disable_ok:
-        logger.warning("Failed to disable OLED output; continuing with final reconcile")
+        if not _apply_input_mode(logger, switch_target["input_target"]):
+            logger.warning("Failed to apply E-Ink input mode; continuing display switch")
 
-    if not display_mgr.finalize_single_display(DISPLAY_EINK, scale=scale):
-        logger.error("Failed to finalize E-Ink output layout")
-        return False
+        apply_stored_orientation(display_mgr, logger, target=switch_target["input_target"])
+        reconcile_touch(
+            logger,
+            display_mgr,
+            target=switch_target["input_target"],
+            reason=switch_target["snapshot_reason"],
+        )
+        _log_post_switch_display_snapshot(logger, switch_target["snapshot_reason"])
+    except Exception as e:
+        logger.warning(f"E-Ink post-convergence follow-up failed: {e}")
 
-    if not disable_ok:
-        logger.warning("E-Ink switch converged after OLED disable failure")
-
-    if not _apply_input_mode(logger, "eink"):
-        logger.warning("Failed to apply E-Ink input mode; continuing display switch")
-
-    apply_stored_orientation(display_mgr, logger, target="eink")
-    reconcile_touch(logger, display_mgr, target="eink", reason="switch_to_eink")
-    _log_post_switch_display_snapshot(logger, "switch_to_eink")
-
-    logger.info("Now using E-Ink")
-    return True
+    if converged:
+        logger.info("Now using E-Ink")
+    return converged
 
 
 def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, script_dir="."):
     logger.info("Switching to OLED...")
-
+    switch_target = _build_switch_target("oled")
     image_process = None
-    image_path = _resolve_privacy_image_path(script_dir)
-    if image_path:
-        logger.info("Displaying privacy image on E-Ink...")
-        image_process = display_mgr.display_fullscreen_image(DISPLAY_EINK, image_path)
-        if image_process:
-            time.sleep(0.5)
-        else:
-            logger.warning("Could not display privacy image")
-    else:
-        logger.warning(f"Privacy image not found: {EINK_DISABLED_IMAGE}")
+    converged = False
 
-    if not helper_command(helper, logger, "disable-eink"):
+    try:
+        try:
+            image_path = _resolve_privacy_image_path(script_dir)
+            if image_path:
+                logger.info("Displaying privacy image on E-Ink...")
+                image_process = display_mgr.display_fullscreen_image(DISPLAY_EINK, image_path)
+                if image_process:
+                    time.sleep(0.5)
+                else:
+                    logger.warning("Could not display privacy image")
+            else:
+                logger.warning(f"Privacy image not found: {EINK_DISABLED_IMAGE}")
+
+            if not helper_command(helper, logger, "disable-eink"):
+                return False
+
+            helper_command(helper, logger, "disable-frontlight")
+            time.sleep(2.0)
+        except Exception as e:
+            logger.error(f"OLED preparation failed: {e}")
+            return False
+
+        try:
+            converged = _converge_single_display(display_mgr, logger, switch_target, scale)
+            if not converged:
+                return False
+        except Exception as e:
+            logger.error(f"OLED display convergence failed: {e}")
+            return False
+
+        try:
+            if autoswitch_theme:
+                set_xfce_theme(logger, switch_target["theme"])
+
+            _restore_dpms_after_eink(logger)
+
+            if not _apply_input_mode(logger, switch_target["input_target"]):
+                logger.warning("Failed to apply OLED input mode; continuing display switch")
+
+            apply_stored_orientation(display_mgr, logger, target=switch_target["input_target"])
+            reconcile_touch(
+                logger,
+                display_mgr,
+                target=switch_target["input_target"],
+                reason=switch_target["snapshot_reason"],
+            )
+            _log_post_switch_display_snapshot(logger, switch_target["snapshot_reason"])
+        except Exception as e:
+            logger.warning(f"OLED post-convergence follow-up failed: {e}")
+
+        if converged:
+            logger.info("Now using OLED")
+        return converged
+    finally:
         if image_process:
             try:
                 image_process.terminate()
+                image_process.wait(timeout=2)
             except Exception:
-                pass
-        return False
-
-    helper_command(helper, logger, "disable-frontlight")
-
-    time.sleep(2.0)
-
-    if image_process:
-        try:
-            image_process.terminate()
-            image_process.wait(timeout=2)
-        except Exception:
-            try:
-                image_process.kill()
-            except Exception:
-                pass
-
-    if not display_mgr.enable_display(DISPLAY_OLED, scale=scale):
-        logger.error("Failed to enable OLED output")
-        return False
-
-    time.sleep(1.0)
-
-    if autoswitch_theme:
-        set_xfce_theme(logger, THEME_ADWAITA_DARK)
-
-    disable_ok = display_mgr.disable_display(DISPLAY_EINK)
-    if not disable_ok:
-        logger.warning("Failed to disable E-Ink output; continuing with final reconcile")
-
-    if not display_mgr.finalize_single_display(DISPLAY_OLED, scale=scale):
-        logger.error("Failed to finalize OLED output layout")
-        return False
-
-    if not disable_ok:
-        logger.warning("OLED switch converged after E-Ink disable failure")
-
-    _restore_dpms_after_eink(logger)
-
-    if not _apply_input_mode(logger, "oled"):
-        logger.warning("Failed to apply OLED input mode; continuing display switch")
-
-    apply_stored_orientation(display_mgr, logger, target="oled")
-    reconcile_touch(logger, display_mgr, target="oled", reason="switch_to_oled")
-    _log_post_switch_display_snapshot(logger, "switch_to_oled")
-
-    logger.info("Now using OLED")
-    return True
+                try:
+                    image_process.kill()
+                except Exception:
+                    pass

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -74,11 +74,30 @@ def set_xfce_theme(logger, theme_name):
 
 
 def _run_xinput(logger, args):
+    command = f"xinput {' '.join(args)}"
+    logger.info(f"Running {command}")
+
     try:
         result = subprocess.run(["xinput", *args], check=True, capture_output=True, text=True)
+        stdout = (result.stdout or "").strip()
+        if stdout:
+            logger.info(f"{command} succeeded: {stdout}")
+        else:
+            logger.info(f"{command} succeeded")
         return result.stdout
+    except subprocess.CalledProcessError as e:
+        details = []
+        stderr = (e.stderr or "").strip()
+        stdout = (e.output or getattr(e, "stdout", "") or "").strip()
+        if stderr:
+            details.append(f"stderr={stderr}")
+        if stdout:
+            details.append(f"stdout={stdout}")
+        detail_suffix = f": {'; '.join(details)}" if details else ""
+        logger.warning(f"{command} failed (rc={e.returncode}){detail_suffix}")
+        return None
     except Exception as e:
-        logger.warning(f"xinput {' '.join(args)} failed: {e}")
+        logger.warning(f"{command} failed: {e}")
         return None
 
 
@@ -97,7 +116,7 @@ def _list_xinput_devices(logger):
         if not device_id.isdigit():
             continue
 
-        device_name = re.sub(r"^[\s⎡⎜⎣↳]+", "", name_part).strip()
+        device_name = re.sub(r"^[^0-9A-Za-z]+", "", name_part).strip()
         devices.append({"id": int(device_id), "name": device_name})
 
     return devices
@@ -120,14 +139,79 @@ def _map_input_to_output(logger, device_id, output_name):
     return _run_xinput(logger, ["map-to-output", str(device_id), output_name]) is not None
 
 
+def _expected_touch_ids_for_target(devices, target):
+    if target == "eink":
+        patterns = EINK_INPUT_PATTERNS
+    elif target == "oled":
+        patterns = OLED_INPUT_PATTERNS
+    else:
+        return []
+
+    return sorted(_find_matching_input_ids(devices, patterns))
+
+
+def _get_device_enabled_state(logger, device_id):
+    output = _run_xinput(logger, ["list-props", str(device_id)])
+    if output is None:
+        return None
+
+    match = re.search(r"Device Enabled \([^)]*\):\s*(\d+)", output)
+    if not match:
+        return None
+
+    return int(match.group(1))
+
+
+def _is_touch_healthy_for_target(logger, target):
+    devices = _list_xinput_devices(logger)
+    if not devices:
+        return False
+
+    expected_ids = _expected_touch_ids_for_target(devices, target)
+    if not expected_ids:
+        return False
+
+    for device_id in expected_ids:
+        if _get_device_enabled_state(logger, device_id) == 1:
+            return True
+    return False
+
+
+def ensure_touch_available(logger, target):
+    if _is_touch_healthy_for_target(logger, target):
+        return True
+
+    logger.warning(f"Touch unavailable for {target}; retrying input remap")
+    _apply_input_mode(logger, target)
+
+    if _is_touch_healthy_for_target(logger, target):
+        logger.info(f"Touch recovered for {target} after input remap retry")
+        return True
+
+    logger.warning(f"Touch still unavailable for {target} after input remap retry")
+    return False
+
+
 def _apply_input_mode(logger, target):
     devices = _list_xinput_devices(logger)
     if not devices:
         logger.warning("No xinput devices found; skipping input mode update")
         return False
 
-    eink_ids = set(_find_matching_input_ids(devices, EINK_INPUT_PATTERNS))
-    oled_ids = set(_find_matching_input_ids(devices, OLED_INPUT_PATTERNS))
+    eink_matches = [
+        device for device in devices
+        if any(fnmatch.fnmatch(device["name"], pattern) for pattern in EINK_INPUT_PATTERNS)
+    ]
+    oled_matches = [
+        device for device in devices
+        if any(fnmatch.fnmatch(device["name"], pattern) for pattern in OLED_INPUT_PATTERNS)
+    ]
+    eink_ids = {device["id"] for device in eink_matches}
+    oled_ids = {device["id"] for device in oled_matches}
+
+    logger.info(
+        f"Input mode {target}: matched E-Ink devices {sorted(eink_ids)}, OLED devices {sorted(oled_ids)}"
+    )
 
     if target == "eink":
         enable_ids = sorted(eink_ids)
@@ -141,6 +225,10 @@ def _apply_input_mode(logger, target):
         logger.warning(f"Unknown input mode target: {target}")
         return False
 
+    logger.info(
+        f"Input mode {target}: target_output={target_output} enable_ids={enable_ids} disable_ids={disable_ids}"
+    )
+
     success = True
     for device_id in enable_ids:
         if not _set_input_enabled(logger, device_id, True):
@@ -152,6 +240,9 @@ def _apply_input_mode(logger, target):
         if not _set_input_enabled(logger, device_id, False):
             success = False
 
+    logger.info(
+        f"Input mode {target} applied {'successfully' if success else 'with failures'}"
+    )
     return success
 
 
@@ -370,6 +461,7 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         logger.warning("Failed to apply E-Ink input mode; continuing display switch")
 
     apply_stored_orientation(display_mgr, logger, target="eink")
+    ensure_touch_available(logger, "eink")
 
     logger.info("Now using E-Ink")
     return True
@@ -431,6 +523,7 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         logger.warning("Failed to apply OLED input mode; continuing display switch")
 
     apply_stored_orientation(display_mgr, logger, target="oled")
+    ensure_touch_available(logger, "oled")
 
     logger.info("Now using OLED")
     return True

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Shared OLED <-> E-Ink mode switching logic for GUI and CLI."""
 
+import json
 import os
+import re
 import subprocess
 import time
 
@@ -10,6 +12,11 @@ DISPLAY_EINK = "eDP-2"
 THEME_HIGH_CONTRAST = "HighContrast"
 THEME_ADWAITA_DARK = "Adwaita-dark"
 EINK_DISABLED_IMAGE = "eink-disable.jpg"
+CONFIG_DIR = os.path.expanduser("~/.config/Tinta4Plus")
+SETTINGS_FILE = os.path.join(CONFIG_DIR, "settings")
+DEFAULT_DPMS_STANDBY = 120
+DEFAULT_DPMS_SUSPEND = 0
+DEFAULT_DPMS_OFF = 600
 
 
 def helper_command(helper, logger, command, **params):
@@ -53,8 +60,141 @@ def _resolve_privacy_image_path(script_dir):
     return None
 
 
+def _load_settings(logger):
+    if not os.path.exists(SETTINGS_FILE):
+        return {}
+    try:
+        with open(SETTINGS_FILE, "r") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception as e:
+        logger.warning(f"Could not read settings for DPMS state: {e}")
+    return {}
+
+
+def _save_settings(logger, settings):
+    try:
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+        with open(SETTINGS_FILE, "w") as f:
+            json.dump(settings, f, indent=2)
+        return True
+    except Exception as e:
+        logger.warning(f"Could not write settings for DPMS state: {e}")
+        return False
+
+
+def _capture_dpms_state(logger):
+    try:
+        result = subprocess.run(["xset", "q"], check=True, capture_output=True, text=True)
+        output = result.stdout
+    except Exception as e:
+        logger.warning(f"Could not query DPMS state via xset: {e}")
+        return None
+
+    enabled = None
+    standby = suspend = off = None
+
+    m_enabled = re.search(r"DPMS is\s+(Enabled|Disabled)", output)
+    if m_enabled:
+        enabled = (m_enabled.group(1) == "Enabled")
+
+    m_timeouts = re.search(r"Standby:\s*(\d+)\s+Suspend:\s*(\d+)\s+Off:\s*(\d+)", output)
+    if m_timeouts:
+        standby = int(m_timeouts.group(1))
+        suspend = int(m_timeouts.group(2))
+        off = int(m_timeouts.group(3))
+
+    if enabled is None or standby is None or suspend is None or off is None:
+        logger.warning("Could not parse full DPMS state from xset output")
+        return None
+
+    return {
+        "enabled": enabled,
+        "standby": standby,
+        "suspend": suspend,
+        "off": off,
+    }
+
+
+def _save_dpms_state(logger, dpms_state):
+    settings = _load_settings(logger)
+    settings["dpms_saved_state"] = dpms_state
+    _save_settings(logger, settings)
+
+
+def _load_dpms_state(logger):
+    settings = _load_settings(logger)
+    value = settings.get("dpms_saved_state")
+    return value if isinstance(value, dict) else None
+
+
+def _clear_dpms_state(logger):
+    settings = _load_settings(logger)
+    if "dpms_saved_state" in settings:
+        del settings["dpms_saved_state"]
+        _save_settings(logger, settings)
+
+
+def _disable_dpms_for_eink(logger):
+    state = _capture_dpms_state(logger)
+    if state:
+        _save_dpms_state(logger, state)
+        logger.info(f"Saved DPMS state: enabled={state['enabled']}, standby={state['standby']}, suspend={state['suspend']}, off={state['off']}")
+
+    try:
+        subprocess.run(["xset", "-dpms"], check=True, capture_output=True)
+        logger.info("Disabled DPMS for E-Ink mode")
+    except Exception as e:
+        logger.warning(f"Could not disable DPMS: {e}")
+
+
+def _restore_dpms_after_eink(logger):
+    state = _load_dpms_state(logger)
+
+    if not state:
+        current = _capture_dpms_state(logger)
+        if current and not current.get("enabled", True):
+            try:
+                subprocess.run(["xset", "+dpms"], check=True, capture_output=True)
+                subprocess.run([
+                    "xset", "dpms",
+                    str(DEFAULT_DPMS_STANDBY),
+                    str(DEFAULT_DPMS_SUSPEND),
+                    str(DEFAULT_DPMS_OFF),
+                ], check=True, capture_output=True)
+                logger.info(
+                    f"No saved DPMS state; DPMS was disabled, applied defaults "
+                    f"({DEFAULT_DPMS_STANDBY}/{DEFAULT_DPMS_SUSPEND}/{DEFAULT_DPMS_OFF})"
+                )
+            except Exception as e:
+                logger.warning(f"Could not apply default DPMS settings: {e}")
+        else:
+            logger.info("No saved DPMS state to restore")
+        return
+
+    try:
+        if state.get("enabled", True):
+            subprocess.run(["xset", "+dpms"], check=True, capture_output=True)
+            subprocess.run([
+                "xset", "dpms",
+                str(state.get("standby", 0)),
+                str(state.get("suspend", 0)),
+                str(state.get("off", 0)),
+            ], check=True, capture_output=True)
+            logger.info("Restored DPMS enabled state and timeouts")
+        else:
+            subprocess.run(["xset", "-dpms"], check=True, capture_output=True)
+            logger.info("Restored DPMS disabled state")
+        _clear_dpms_state(logger)
+    except Exception as e:
+        logger.warning(f"Could not restore DPMS state: {e}")
+
+
 def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, enable_frontlight=True, brightness_level=4):
     logger.info("Switching to E-Ink...")
+
+    _disable_dpms_for_eink(logger)
 
     if autoswitch_theme:
         set_xfce_theme(logger, THEME_HIGH_CONTRAST)
@@ -132,6 +272,8 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     if autoswitch_theme:
         set_xfce_theme(logger, THEME_ADWAITA_DARK)
+
+    _restore_dpms_after_eink(logger)
 
     logger.info("Now using OLED")
     return True

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -18,6 +18,24 @@ SETTINGS_FILE = os.path.join(CONFIG_DIR, "settings")
 DEFAULT_DPMS_STANDBY = 120
 DEFAULT_DPMS_SUSPEND = 0
 DEFAULT_DPMS_OFF = 600
+DISPLAY_POWER_SAVED_STATE_KEY = "display_power_saved_state"
+LEGACY_DPMS_SAVED_STATE_KEY = "dpms_saved_state"
+XFCE_POWER_MANAGER_CHANNEL = "xfce4-power-manager"
+XFCE_POWER_MANAGER_KEYS = {
+    "/xfce4-power-manager/dpms-enabled": "bool",
+    "/xfce4-power-manager/blank-on-ac": "int",
+    "/xfce4-power-manager/blank-on-battery": "int",
+    "/xfce4-power-manager/dpms-on-ac-sleep": "int",
+    "/xfce4-power-manager/dpms-on-ac-off": "int",
+    "/xfce4-power-manager/pre-blank-command": "string",
+}
+XFCE_EINK_POWER_POLICY = {
+    "/xfce4-power-manager/dpms-enabled": "false",
+    "/xfce4-power-manager/blank-on-ac": "0",
+    "/xfce4-power-manager/blank-on-battery": "0",
+    "/xfce4-power-manager/dpms-on-ac-sleep": "0",
+    "/xfce4-power-manager/dpms-on-ac-off": "0",
+}
 EINK_INPUT_PATTERNS = ["ITE Tech. Inc. ITE T-CON*"]
 OLED_INPUT_PATTERNS = ["Wacom HID 537D*"]
 SUPPORTED_ORIENTATION_ROTATIONS = {"normal", "left"}
@@ -426,63 +444,166 @@ def apply_stored_orientation(display_mgr, logger, target):
     return True
 
 
-def _capture_dpms_state(logger):
+def _capture_xset_display_power_state(logger):
     try:
         result = subprocess.run(["xset", "q"], check=True, capture_output=True, text=True)
         output = result.stdout
     except Exception as e:
-        logger.warning(f"Could not query DPMS state via xset: {e}")
+        logger.warning(f"Could not query display power state via xset: {e}")
         return None
 
-    enabled = None
-    standby = suspend = off = None
+    screensaver_timeout = screensaver_cycle = None
+    dpms_enabled = None
+    dpms_standby = dpms_suspend = dpms_off = None
+
+    m_screensaver = re.search(r"timeout:\s*(\d+)\s+cycle:\s*(\d+)", output)
+    if m_screensaver:
+        screensaver_timeout = int(m_screensaver.group(1))
+        screensaver_cycle = int(m_screensaver.group(2))
 
     m_enabled = re.search(r"DPMS is\s+(Enabled|Disabled)", output)
     if m_enabled:
-        enabled = (m_enabled.group(1) == "Enabled")
+        dpms_enabled = (m_enabled.group(1) == "Enabled")
 
     m_timeouts = re.search(r"Standby:\s*(\d+)\s+Suspend:\s*(\d+)\s+Off:\s*(\d+)", output)
     if m_timeouts:
-        standby = int(m_timeouts.group(1))
-        suspend = int(m_timeouts.group(2))
-        off = int(m_timeouts.group(3))
+        dpms_standby = int(m_timeouts.group(1))
+        dpms_suspend = int(m_timeouts.group(2))
+        dpms_off = int(m_timeouts.group(3))
 
-    if enabled is None or standby is None or suspend is None or off is None:
-        logger.warning("Could not parse full DPMS state from xset output")
+    if (
+        screensaver_timeout is None
+        or screensaver_cycle is None
+        or dpms_enabled is None
+        or dpms_standby is None
+        or dpms_suspend is None
+        or dpms_off is None
+    ):
+        logger.warning("Could not parse full display power state from xset output")
         return None
 
     return {
-        "enabled": enabled,
-        "standby": standby,
-        "suspend": suspend,
-        "off": off,
+        "screensaver_timeout": screensaver_timeout,
+        "screensaver_cycle": screensaver_cycle,
+        "dpms_enabled": dpms_enabled,
+        "dpms_standby": dpms_standby,
+        "dpms_suspend": dpms_suspend,
+        "dpms_off": dpms_off,
     }
 
 
-def _save_dpms_state(logger, dpms_state):
+def _coerce_xfce_value(value_type, raw_value):
+    value = raw_value.strip()
+    if value_type == "bool":
+        return value.lower() in ("1", "true", "yes")
+    if value_type == "int":
+        return int(value)
+    return value
+
+
+def _format_xfce_value(saved_value):
+    value_type = saved_value.get("type")
+    value = saved_value.get("value")
+    if value_type == "bool":
+        return "true" if value else "false"
+    return str(value)
+
+
+def _run_xfce_power_manager_query(logger, key):
+    try:
+        result = subprocess.run([
+            "xfconf-query", "-c", XFCE_POWER_MANAGER_CHANNEL, "-p", key,
+        ], check=True, capture_output=True, text=True)
+        return result.stdout
+    except Exception as e:
+        logger.warning(f"Could not query XFCE power-manager key {key}: {e}")
+        return None
+
+
+def _run_xfce_power_manager_set(logger, key, value):
+    try:
+        subprocess.run([
+            "xfconf-query", "-c", XFCE_POWER_MANAGER_CHANNEL, "-p", key, "-s", value,
+        ], check=True, capture_output=True, text=True)
+        return True
+    except Exception as e:
+        logger.warning(f"Could not set XFCE power-manager key {key}={value}: {e}")
+        return False
+
+
+def _capture_xfce_power_manager_state(logger):
+    state = {}
+    for key, value_type in XFCE_POWER_MANAGER_KEYS.items():
+        raw_value = _run_xfce_power_manager_query(logger, key)
+        if raw_value is None:
+            continue
+        try:
+            state[key] = {
+                "type": value_type,
+                "value": _coerce_xfce_value(value_type, raw_value),
+            }
+        except Exception as e:
+            logger.warning(f"Could not parse XFCE power-manager key {key}: {e}")
+    return state
+
+
+def _capture_display_power_state(logger):
+    state = {}
+    xset_state = _capture_xset_display_power_state(logger)
+    if xset_state:
+        state["xset"] = xset_state
+
+    xfce_state = _capture_xfce_power_manager_state(logger)
+    if xfce_state:
+        state["xfce_power_manager"] = xfce_state
+
+    return state if state else None
+
+
+def _save_display_power_state(logger, display_power_state):
     settings = _load_settings(logger)
-    settings["dpms_saved_state"] = dpms_state
+    settings[DISPLAY_POWER_SAVED_STATE_KEY] = display_power_state
+    if LEGACY_DPMS_SAVED_STATE_KEY in settings:
+        del settings[LEGACY_DPMS_SAVED_STATE_KEY]
     _save_settings(logger, settings)
 
 
-def _load_dpms_state(logger):
+def _load_display_power_state(logger):
     settings = _load_settings(logger)
-    value = settings.get("dpms_saved_state")
-    return value if isinstance(value, dict) else None
+    value = settings.get(DISPLAY_POWER_SAVED_STATE_KEY)
+    if isinstance(value, dict):
+        return value
+
+    legacy = settings.get(LEGACY_DPMS_SAVED_STATE_KEY)
+    if isinstance(legacy, dict):
+        return {
+            "legacy_dpms": legacy,
+        }
+    return None
 
 
-def _clear_dpms_state(logger):
+def _has_saved_display_power_state(logger):
     settings = _load_settings(logger)
-    if "dpms_saved_state" in settings:
-        del settings["dpms_saved_state"]
+    return isinstance(settings.get(DISPLAY_POWER_SAVED_STATE_KEY), dict)
+
+
+def _clear_display_power_state(logger):
+    settings = _load_settings(logger)
+    changed = False
+    for key in (DISPLAY_POWER_SAVED_STATE_KEY, LEGACY_DPMS_SAVED_STATE_KEY):
+        if key in settings:
+            del settings[key]
+            changed = True
+    if changed:
         _save_settings(logger, settings)
 
 
-def _disable_dpms_for_eink(logger):
-    state = _capture_dpms_state(logger)
-    if state:
-        _save_dpms_state(logger, state)
-        logger.info(f"Saved DPMS state: enabled={state['enabled']}, standby={state['standby']}, suspend={state['suspend']}, off={state['off']}")
+def _apply_eink_display_power_policy(logger):
+    try:
+        subprocess.run(["xset", "s", "off"], check=True, capture_output=True)
+        logger.info("Disabled X11 screensaver for E-Ink mode")
+    except Exception as e:
+        logger.warning(f"Could not disable X11 screensaver: {e}")
 
     try:
         subprocess.run(["xset", "-dpms"], check=True, capture_output=True)
@@ -490,13 +611,65 @@ def _disable_dpms_for_eink(logger):
     except Exception as e:
         logger.warning(f"Could not disable DPMS: {e}")
 
+    for key, value in XFCE_EINK_POWER_POLICY.items():
+        _run_xfce_power_manager_set(logger, key, value)
+
+
+def _restore_xset_display_power_state(logger, state):
+    subprocess.run([
+        "xset", "s",
+        str(state.get("screensaver_timeout", 0)),
+        str(state.get("screensaver_cycle", 0)),
+    ], check=True, capture_output=True)
+
+    if state.get("dpms_enabled", True):
+        subprocess.run(["xset", "+dpms"], check=True, capture_output=True)
+        subprocess.run([
+            "xset", "dpms",
+            str(state.get("dpms_standby", 0)),
+            str(state.get("dpms_suspend", 0)),
+            str(state.get("dpms_off", 0)),
+        ], check=True, capture_output=True)
+    else:
+        subprocess.run(["xset", "-dpms"], check=True, capture_output=True)
+
+
+def _restore_legacy_dpms_state(logger, state):
+    if state.get("enabled", True):
+        subprocess.run(["xset", "+dpms"], check=True, capture_output=True)
+        subprocess.run([
+            "xset", "dpms",
+            str(state.get("standby", 0)),
+            str(state.get("suspend", 0)),
+            str(state.get("off", 0)),
+        ], check=True, capture_output=True)
+    else:
+        subprocess.run(["xset", "-dpms"], check=True, capture_output=True)
+
+
+def _restore_xfce_power_manager_state(logger, state):
+    for key, saved_value in state.items():
+        _run_xfce_power_manager_set(logger, key, _format_xfce_value(saved_value))
+
+
+def _disable_dpms_for_eink(logger):
+    if not _has_saved_display_power_state(logger):
+        state = _capture_display_power_state(logger)
+        if state:
+            _save_display_power_state(logger, state)
+            logger.info("Saved display power policy for OLED mode")
+    else:
+        logger.info("Display power policy already saved; not overwriting OLED snapshot")
+
+    _apply_eink_display_power_policy(logger)
+
 
 def _restore_dpms_after_eink(logger):
-    state = _load_dpms_state(logger)
+    state = _load_display_power_state(logger)
 
     if not state:
-        current = _capture_dpms_state(logger)
-        if current and not current.get("enabled", True):
+        current = _capture_xset_display_power_state(logger)
+        if current and not current.get("dpms_enabled", True):
             try:
                 subprocess.run(["xset", "+dpms"], check=True, capture_output=True)
                 subprocess.run([
@@ -506,31 +679,28 @@ def _restore_dpms_after_eink(logger):
                     str(DEFAULT_DPMS_OFF),
                 ], check=True, capture_output=True)
                 logger.info(
-                    f"No saved DPMS state; DPMS was disabled, applied defaults "
+                    f"No saved display power policy; DPMS was disabled, applied defaults "
                     f"({DEFAULT_DPMS_STANDBY}/{DEFAULT_DPMS_SUSPEND}/{DEFAULT_DPMS_OFF})"
                 )
             except Exception as e:
                 logger.warning(f"Could not apply default DPMS settings: {e}")
         else:
-            logger.info("No saved DPMS state to restore")
+            logger.info("No saved display power policy to restore")
         return
 
     try:
-        if state.get("enabled", True):
-            subprocess.run(["xset", "+dpms"], check=True, capture_output=True)
-            subprocess.run([
-                "xset", "dpms",
-                str(state.get("standby", 0)),
-                str(state.get("suspend", 0)),
-                str(state.get("off", 0)),
-            ], check=True, capture_output=True)
-            logger.info("Restored DPMS enabled state and timeouts")
-        else:
-            subprocess.run(["xset", "-dpms"], check=True, capture_output=True)
-            logger.info("Restored DPMS disabled state")
-        _clear_dpms_state(logger)
+        if "xset" in state:
+            _restore_xset_display_power_state(logger, state["xset"])
+            logger.info("Restored X11 screensaver and DPMS policy")
+        if "legacy_dpms" in state:
+            _restore_legacy_dpms_state(logger, state["legacy_dpms"])
+            logger.info("Restored legacy DPMS policy")
+        if "xfce_power_manager" in state:
+            _restore_xfce_power_manager_state(logger, state["xfce_power_manager"])
+            logger.info("Restored XFCE power-manager policy")
+        _clear_display_power_state(logger)
     except Exception as e:
-        logger.warning(f"Could not restore DPMS state: {e}")
+        logger.warning(f"Could not restore display power policy: {e}")
 
 
 def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, enable_frontlight=True, brightness_level=4):

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -101,6 +101,35 @@ def _run_xinput(logger, args):
         return None
 
 
+def _log_post_switch_display_snapshot(logger, reason):
+    """Log concise xrandr state after a display mode switch."""
+    try:
+        query = subprocess.run(["xrandr", "--query"], check=True, capture_output=True, text=True)
+        lines = (query.stdout or "").splitlines()
+
+        screen_line = next((line.strip() for line in lines if line.startswith("Screen ")), "<missing>")
+        active_outputs = []
+        for line in lines:
+            if " connected" not in line:
+                continue
+            if re.search(r"\b\d+x\d+\+\d+\+\d+\b", line):
+                active_outputs.append(line.strip())
+
+        outputs_summary = " | ".join(active_outputs) if active_outputs else "<none>"
+        logger.info(f"Display snapshot ({reason}): {screen_line}")
+        logger.info(f"Display snapshot ({reason}) active outputs: {outputs_summary}")
+    except Exception as e:
+        logger.warning(f"Display snapshot ({reason}) xrandr --query failed: {e}")
+        return
+
+    try:
+        monitors = subprocess.run(["xrandr", "--listactivemonitors"], check=True, capture_output=True, text=True)
+        monitor_lines = [line.strip() for line in (monitors.stdout or "").splitlines() if line.strip()]
+        logger.info(f"Display snapshot ({reason}) monitors: {' || '.join(monitor_lines)}")
+    except Exception as e:
+        logger.warning(f"Display snapshot ({reason}) xrandr --listactivemonitors failed: {e}")
+
+
 def _list_xinput_devices(logger):
     output = _run_xinput(logger, ["--list", "--short"])
     if output is None:
@@ -486,6 +515,7 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     apply_stored_orientation(display_mgr, logger, target="eink")
     reconcile_touch(logger, display_mgr, target="eink", reason="switch_to_eink")
+    _log_post_switch_display_snapshot(logger, "switch_to_eink")
 
     logger.info("Now using E-Ink")
     return True
@@ -548,6 +578,7 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     apply_stored_orientation(display_mgr, logger, target="oled")
     reconcile_touch(logger, display_mgr, target="oled", reason="switch_to_oled")
+    _log_post_switch_display_snapshot(logger, "switch_to_oled")
 
     logger.info("Now using OLED")
     return True

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -510,6 +510,10 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         logger.error("Failed to disable OLED output")
         return False
 
+    if not display_mgr.finalize_single_display(DISPLAY_EINK, scale=scale):
+        logger.error("Failed to finalize E-Ink output layout")
+        return False
+
     if not _apply_input_mode(logger, "eink"):
         logger.warning("Failed to apply E-Ink input mode; continuing display switch")
 
@@ -566,6 +570,10 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     if not display_mgr.disable_display(DISPLAY_EINK):
         logger.error("Failed to disable E-Ink output")
+        return False
+
+    if not display_mgr.finalize_single_display(DISPLAY_OLED, scale=scale):
+        logger.error("Failed to finalize OLED output layout")
         return False
 
     if autoswitch_theme:

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -114,6 +114,10 @@ def _set_input_enabled(logger, device_id, enabled):
     return _run_xinput(logger, [action, str(device_id)]) is not None
 
 
+def _map_input_to_output(logger, device_id, output_name):
+    return _run_xinput(logger, ["map-to-output", str(device_id), output_name]) is not None
+
+
 def _apply_input_mode(logger, target):
     devices = _list_xinput_devices(logger)
     if not devices:
@@ -126,9 +130,11 @@ def _apply_input_mode(logger, target):
     if target == "eink":
         enable_ids = sorted(eink_ids)
         disable_ids = sorted(oled_ids - eink_ids)
+        target_output = DISPLAY_EINK
     elif target == "oled":
         enable_ids = sorted(oled_ids)
         disable_ids = sorted(eink_ids - oled_ids)
+        target_output = DISPLAY_OLED
     else:
         logger.warning(f"Unknown input mode target: {target}")
         return False
@@ -136,6 +142,8 @@ def _apply_input_mode(logger, target):
     success = True
     for device_id in enable_ids:
         if not _set_input_enabled(logger, device_id, True):
+            success = False
+        if not _map_input_to_output(logger, device_id, target_output):
             success = False
 
     for device_id in disable_ids:

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -571,6 +571,9 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     time.sleep(1.0)
 
+    if autoswitch_theme:
+        set_xfce_theme(logger, THEME_ADWAITA_DARK)
+
     disable_ok = display_mgr.disable_display(DISPLAY_EINK)
     if not disable_ok:
         logger.warning("Failed to disable E-Ink output; continuing with final reconcile")
@@ -581,9 +584,6 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     if not disable_ok:
         logger.warning("OLED switch converged after E-Ink disable failure")
-
-    if autoswitch_theme:
-        set_xfce_theme(logger, THEME_ADWAITA_DARK)
 
     _restore_dpms_after_eink(logger)
 

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Shared OLED <-> E-Ink mode switching logic for GUI and CLI."""
 
+import fnmatch
 import json
 import os
 import re
@@ -17,6 +18,28 @@ SETTINGS_FILE = os.path.join(CONFIG_DIR, "settings")
 DEFAULT_DPMS_STANDBY = 120
 DEFAULT_DPMS_SUSPEND = 0
 DEFAULT_DPMS_OFF = 600
+EINK_INPUT_PATTERNS = ["ITE Tech. Inc. ITE T-CON*"]
+OLED_INPUT_PATTERNS = ["Wacom HID 537D*"]
+
+
+def get_display_state(display_mgr):
+    oled_active = display_mgr.is_display_active(DISPLAY_OLED)
+    eink_active = display_mgr.is_display_active(DISPLAY_EINK)
+
+    if oled_active and eink_active:
+        mode = "mixed"
+    elif oled_active:
+        mode = "oled"
+    elif eink_active:
+        mode = "eink"
+    else:
+        mode = "unknown"
+
+    return {
+        "oled_active": oled_active,
+        "eink_active": eink_active,
+        "mode": mode,
+    }
 
 
 def helper_command(helper, logger, command, **params):
@@ -46,6 +69,80 @@ def set_xfce_theme(logger, theme_name):
     except Exception as e:
         logger.warning(f"Failed to set theme to {theme_name}: {e}")
         return False
+
+
+def _run_xinput(logger, args):
+    try:
+        result = subprocess.run(["xinput", *args], check=True, capture_output=True, text=True)
+        return result.stdout
+    except Exception as e:
+        logger.warning(f"xinput {' '.join(args)} failed: {e}")
+        return None
+
+
+def _list_xinput_devices(logger):
+    output = _run_xinput(logger, ["--list", "--short"])
+    if output is None:
+        return []
+
+    devices = []
+    for line in output.splitlines():
+        if "id=" not in line:
+            continue
+
+        name_part, id_part = line.split("id=", 1)
+        device_id = id_part.split()[0]
+        if not device_id.isdigit():
+            continue
+
+        device_name = re.sub(r"^[\s⎡⎜⎣↳]+", "", name_part).strip()
+        devices.append({"id": int(device_id), "name": device_name})
+
+    return devices
+
+
+def _find_matching_input_ids(devices, patterns):
+    return [
+        device["id"]
+        for device in devices
+        if any(fnmatch.fnmatch(device["name"], pattern) for pattern in patterns)
+    ]
+
+
+def _set_input_enabled(logger, device_id, enabled):
+    action = "enable" if enabled else "disable"
+    return _run_xinput(logger, [action, str(device_id)]) is not None
+
+
+def _apply_input_mode(logger, target):
+    devices = _list_xinput_devices(logger)
+    if not devices:
+        logger.warning("No xinput devices found; skipping input mode update")
+        return False
+
+    eink_ids = set(_find_matching_input_ids(devices, EINK_INPUT_PATTERNS))
+    oled_ids = set(_find_matching_input_ids(devices, OLED_INPUT_PATTERNS))
+
+    if target == "eink":
+        enable_ids = sorted(eink_ids)
+        disable_ids = sorted(oled_ids - eink_ids)
+    elif target == "oled":
+        enable_ids = sorted(oled_ids)
+        disable_ids = sorted(eink_ids - oled_ids)
+    else:
+        logger.warning(f"Unknown input mode target: {target}")
+        return False
+
+    success = True
+    for device_id in enable_ids:
+        if not _set_input_enabled(logger, device_id, True):
+            success = False
+
+    for device_id in disable_ids:
+        if not _set_input_enabled(logger, device_id, False):
+            success = False
+
+    return success
 
 
 def _resolve_privacy_image_path(script_dir):
@@ -219,6 +316,9 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         logger.error("Failed to disable OLED output")
         return False
 
+    if not _apply_input_mode(logger, "eink"):
+        logger.warning("Failed to apply E-Ink input mode; continuing display switch")
+
     logger.info("Now using E-Ink")
     return True
 
@@ -274,6 +374,9 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         set_xfce_theme(logger, THEME_ADWAITA_DARK)
 
     _restore_dpms_after_eink(logger)
+
+    if not _apply_input_mode(logger, "oled"):
+        logger.warning("Failed to apply OLED input mode; continuing display switch")
 
     logger.info("Now using OLED")
     return True

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -192,6 +192,30 @@ def ensure_touch_available(logger, target):
     return False
 
 
+def reconcile_touch(logger, display_mgr, target=None, reason="unspecified"):
+    resolved_target = target
+
+    if resolved_target is None:
+        mode = get_display_state(display_mgr).get("mode")
+        if mode in ("eink", "oled"):
+            resolved_target = mode
+        else:
+            logger.info(f"Touch reconcile skipped (reason={reason}, mode={mode})")
+            return False
+
+    if resolved_target not in ("eink", "oled"):
+        logger.warning(f"Touch reconcile skipped (reason={reason}, invalid_target={resolved_target})")
+        return False
+
+    recovered = ensure_touch_available(logger, resolved_target)
+    if recovered:
+        logger.info(f"Touch reconcile succeeded (reason={reason}, target={resolved_target})")
+        return True
+
+    logger.warning(f"Touch reconcile failed (reason={reason}, target={resolved_target})")
+    return False
+
+
 def _apply_input_mode(logger, target):
     devices = _list_xinput_devices(logger)
     if not devices:
@@ -461,7 +485,7 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         logger.warning("Failed to apply E-Ink input mode; continuing display switch")
 
     apply_stored_orientation(display_mgr, logger, target="eink")
-    ensure_touch_available(logger, "eink")
+    reconcile_touch(logger, display_mgr, target="eink", reason="switch_to_eink")
 
     logger.info("Now using E-Ink")
     return True
@@ -523,7 +547,7 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
         logger.warning("Failed to apply OLED input mode; continuing display switch")
 
     apply_stored_orientation(display_mgr, logger, target="oled")
-    ensure_touch_available(logger, "oled")
+    reconcile_touch(logger, display_mgr, target="oled", reason="switch_to_oled")
 
     logger.info("Now using OLED")
     return True

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Shared OLED <-> E-Ink mode switching logic for GUI and CLI."""
+
+import os
+import subprocess
+import time
+
+DISPLAY_OLED = "eDP-1"
+DISPLAY_EINK = "eDP-2"
+THEME_HIGH_CONTRAST = "HighContrast"
+THEME_ADWAITA_DARK = "Adwaita-dark"
+EINK_DISABLED_IMAGE = "eink-disable.jpg"
+
+
+def helper_command(helper, logger, command, **params):
+    try:
+        response = helper.send_command(command, **params)
+    except Exception as e:
+        logger.error(f"{command} exception: {e}")
+        return False
+
+    if not response or not response.get("success"):
+        error = (response or {}).get("error", "unknown error")
+        logger.error(f"{command} failed: {error}")
+        return False
+    return True
+
+
+def set_xfce_theme(logger, theme_name):
+    try:
+        subprocess.run([
+            "xfconf-query",
+            "-c", "xsettings",
+            "-p", "/Net/ThemeName",
+            "-s", theme_name,
+        ], check=True, capture_output=True)
+        logger.info(f"Switched to {theme_name} theme")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to set theme to {theme_name}: {e}")
+        return False
+
+
+def _resolve_privacy_image_path(script_dir):
+    image_path = EINK_DISABLED_IMAGE
+    if os.path.exists(image_path):
+        return image_path
+
+    image_path = os.path.join(script_dir, EINK_DISABLED_IMAGE)
+    if os.path.exists(image_path):
+        return image_path
+
+    return None
+
+
+def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, enable_frontlight=True, brightness_level=4):
+    logger.info("Switching to E-Ink...")
+
+    if autoswitch_theme:
+        set_xfce_theme(logger, THEME_HIGH_CONTRAST)
+
+    if not display_mgr.enable_display(DISPLAY_EINK, scale=scale):
+        logger.error("Failed to enable E-Ink display output")
+        return False
+
+    time.sleep(1.0)
+
+    if not helper_command(helper, logger, "enable-eink"):
+        logger.error("Rolling back: enabling OLED display")
+        display_mgr.enable_display(DISPLAY_OLED, scale=scale)
+        return False
+
+    if enable_frontlight:
+        helper_command(helper, logger, "enable-frontlight", brightness_level=brightness_level)
+
+    time.sleep(0.5)
+
+    if not display_mgr.disable_display(DISPLAY_OLED):
+        logger.error("Failed to disable OLED output")
+        return False
+
+    logger.info("Now using E-Ink")
+    return True
+
+
+def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, script_dir="."):
+    logger.info("Switching to OLED...")
+
+    image_process = None
+    image_path = _resolve_privacy_image_path(script_dir)
+    if image_path:
+        logger.info("Displaying privacy image on E-Ink...")
+        image_process = display_mgr.display_fullscreen_image(DISPLAY_EINK, image_path)
+        if image_process:
+            time.sleep(0.5)
+        else:
+            logger.warning("Could not display privacy image")
+    else:
+        logger.warning(f"Privacy image not found: {EINK_DISABLED_IMAGE}")
+
+    if not helper_command(helper, logger, "disable-eink"):
+        if image_process:
+            try:
+                image_process.terminate()
+            except Exception:
+                pass
+        return False
+
+    helper_command(helper, logger, "disable-frontlight")
+
+    time.sleep(2.0)
+
+    if image_process:
+        try:
+            image_process.terminate()
+            image_process.wait(timeout=2)
+        except Exception:
+            try:
+                image_process.kill()
+            except Exception:
+                pass
+
+    if not display_mgr.enable_display(DISPLAY_OLED, scale=scale):
+        logger.error("Failed to enable OLED output")
+        return False
+
+    time.sleep(1.0)
+
+    if not display_mgr.disable_display(DISPLAY_EINK):
+        logger.error("Failed to disable E-Ink output")
+        return False
+
+    if autoswitch_theme:
+        set_xfce_theme(logger, THEME_ADWAITA_DARK)
+
+    logger.info("Now using OLED")
+    return True

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -482,23 +482,6 @@ def _restore_dpms_after_eink(logger):
         logger.warning(f"Could not restore DPMS state: {e}")
 
 
-def _attempt_finalize_reconcile(display_mgr, logger, display_name, scale):
-    """Best-effort layout reconcile to keep active output usable after partial switch failures."""
-    try:
-        if display_mgr.finalize_single_display(display_name, scale=scale):
-            logger.warning(
-                f"Recovered {display_name} layout with best-effort finalize after transition failure"
-            )
-            return True
-        logger.warning(
-            f"Best-effort finalize failed for {display_name} after transition failure"
-        )
-        return False
-    except Exception as e:
-        logger.warning(f"Best-effort finalize raised for {display_name}: {e}")
-        return False
-
-
 def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=True, enable_frontlight=True, brightness_level=4):
     logger.info("Switching to E-Ink...")
 
@@ -523,14 +506,16 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     time.sleep(0.5)
 
-    if not display_mgr.disable_display(DISPLAY_OLED):
-        logger.error("Failed to disable OLED output")
-        _attempt_finalize_reconcile(display_mgr, logger, DISPLAY_EINK, scale)
-        return False
+    disable_ok = display_mgr.disable_display(DISPLAY_OLED)
+    if not disable_ok:
+        logger.warning("Failed to disable OLED output; continuing with final reconcile")
 
     if not display_mgr.finalize_single_display(DISPLAY_EINK, scale=scale):
         logger.error("Failed to finalize E-Ink output layout")
         return False
+
+    if not disable_ok:
+        logger.warning("E-Ink switch converged after OLED disable failure")
 
     if not _apply_input_mode(logger, "eink"):
         logger.warning("Failed to apply E-Ink input mode; continuing display switch")
@@ -586,14 +571,16 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     time.sleep(1.0)
 
-    if not display_mgr.disable_display(DISPLAY_EINK):
-        logger.error("Failed to disable E-Ink output")
-        _attempt_finalize_reconcile(display_mgr, logger, DISPLAY_OLED, scale)
-        return False
+    disable_ok = display_mgr.disable_display(DISPLAY_EINK)
+    if not disable_ok:
+        logger.warning("Failed to disable E-Ink output; continuing with final reconcile")
 
     if not display_mgr.finalize_single_display(DISPLAY_OLED, scale=scale):
         logger.error("Failed to finalize OLED output layout")
         return False
+
+    if not disable_ok:
+        logger.warning("OLED switch converged after E-Ink disable failure")
 
     if autoswitch_theme:
         set_xfce_theme(logger, THEME_ADWAITA_DARK)

--- a/mode_switch.py
+++ b/mode_switch.py
@@ -20,6 +20,8 @@ DEFAULT_DPMS_SUSPEND = 0
 DEFAULT_DPMS_OFF = 600
 EINK_INPUT_PATTERNS = ["ITE Tech. Inc. ITE T-CON*"]
 OLED_INPUT_PATTERNS = ["Wacom HID 537D*"]
+SUPPORTED_ORIENTATION_ROTATIONS = {"normal", "left"}
+ORIENTATION_PREFERENCE_KEY = "orientation_preference"
 
 
 def get_display_state(display_mgr):
@@ -189,6 +191,46 @@ def _save_settings(logger, settings):
         return False
 
 
+def load_orientation_preference(logger):
+    settings = _load_settings(logger)
+    value = settings.get(ORIENTATION_PREFERENCE_KEY)
+    if value in SUPPORTED_ORIENTATION_ROTATIONS:
+        return value
+    if value is not None:
+        logger.warning(f"Ignoring unsupported orientation preference '{value}'")
+    return None
+
+
+def save_orientation_preference(logger, rotation):
+    if rotation not in SUPPORTED_ORIENTATION_ROTATIONS:
+        logger.warning(f"Refusing to save unsupported orientation '{rotation}'")
+        return False
+
+    settings = _load_settings(logger)
+    settings[ORIENTATION_PREFERENCE_KEY] = rotation
+    return _save_settings(logger, settings)
+
+
+def apply_stored_orientation(display_mgr, logger, target):
+    rotation = load_orientation_preference(logger)
+    if rotation is None:
+        return False
+
+    active_display = display_mgr.get_active_display()
+    if not active_display:
+        logger.warning("No active display found for orientation re-apply")
+        return False
+
+    if not display_mgr.set_display_rotation(active_display, rotation):
+        logger.warning(f"Failed to apply stored orientation '{rotation}' on {active_display}")
+        return False
+
+    if not _apply_input_mode(logger, target):
+        logger.warning(f"Applied orientation on {active_display}, but input remap failed for {target}")
+
+    return True
+
+
 def _capture_dpms_state(logger):
     try:
         result = subprocess.run(["xset", "q"], check=True, capture_output=True, text=True)
@@ -327,6 +369,8 @@ def switch_to_eink(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
     if not _apply_input_mode(logger, "eink"):
         logger.warning("Failed to apply E-Ink input mode; continuing display switch")
 
+    apply_stored_orientation(display_mgr, logger, target="eink")
+
     logger.info("Now using E-Ink")
     return True
 
@@ -385,6 +429,8 @@ def switch_to_oled(display_mgr, helper, logger, scale=1.75, autoswitch_theme=Tru
 
     if not _apply_input_mode(logger, "oled"):
         logger.warning("Failed to apply OLED input mode; continuing display switch")
+
+    apply_stored_orientation(display_mgr, logger, target="oled")
 
     logger.info("Now using OLED")
     return True

--- a/scripts/install-systemd-helper-root.sh
+++ b/scripts/install-systemd-helper-root.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="install"
+USER_NAME=""
+SOURCE_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --user)
+      USER_NAME="${2:-}"
+      shift 2
+      ;;
+    --source-dir)
+      SOURCE_DIR="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$SOURCE_DIR" ]]; then
+  echo "Usage: $0 [--check] --source-dir <path> [--user <username>]" >&2
+  exit 2
+fi
+
+if [[ "$MODE" == "install" && $EUID -ne 0 ]]; then
+  echo "This script must run as root" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "install" && -z "$USER_NAME" ]]; then
+  echo "Install mode requires --user <username>" >&2
+  exit 2
+fi
+
+HELPER_SRC="$SOURCE_DIR/HelperDaemon.py"
+WATCHDOG_SRC="$SOURCE_DIR/WatchdogTimer.py"
+EC_SRC="$SOURCE_DIR/ECController.py"
+EINK_SRC="$SOURCE_DIR/EInkUSBController.py"
+SOCKET_UNIT_SRC="$SOURCE_DIR/contrib/systemd/tinta4plus-helper.socket"
+SERVICE_UNIT_SRC="$SOURCE_DIR/contrib/systemd/tinta4plus-helper.service"
+INSTALL_DIR="/usr/local/lib/tinta4plus"
+DESKTOP_FILE="/usr/share/applications/eink-tinta4plus.desktop"
+APP_MAIN="$SOURCE_DIR/Tinta4Plus.py"
+
+[[ -f "$HELPER_SRC" ]] || { echo "Missing $HELPER_SRC" >&2; exit 1; }
+[[ -f "$WATCHDOG_SRC" ]] || { echo "Missing $WATCHDOG_SRC" >&2; exit 1; }
+[[ -f "$EC_SRC" ]] || { echo "Missing $EC_SRC" >&2; exit 1; }
+[[ -f "$EINK_SRC" ]] || { echo "Missing $EINK_SRC" >&2; exit 1; }
+[[ -f "$SOCKET_UNIT_SRC" ]] || { echo "Missing $SOCKET_UNIT_SRC" >&2; exit 1; }
+[[ -f "$SERVICE_UNIT_SRC" ]] || { echo "Missing $SERVICE_UNIT_SRC" >&2; exit 1; }
+[[ -f "$APP_MAIN" ]] || { echo "Missing $APP_MAIN" >&2; exit 1; }
+
+pick_icon_path() {
+  local candidates=(
+    "/usr/share/icons/elementary-xfce/apps/48/preferences-desktop-display.png"
+    "/usr/share/icons/HighContrast/48x48/apps/preferences-desktop-display.png"
+    "/usr/share/icons/HighContrast/32x32/apps/preferences-desktop-display.png"
+    "/usr/share/icons/hicolor/48x48/status/display-brightness.png"
+  )
+
+  for icon in "${candidates[@]}"; do
+    if [[ -f "$icon" ]]; then
+      echo "$icon"
+      return 0
+    fi
+  done
+
+  echo "video-display-symbolic"
+}
+
+write_desktop_file() {
+  local icon="$1"
+  cat > "$2" <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=EInk-Tinta4+
+Comment=Control ThinkBook Plus E-Ink display
+Exec=$APP_MAIN
+TryExec=$APP_MAIN
+Path=$SOURCE_DIR
+Icon=$icon
+Terminal=false
+Categories=System;
+StartupNotify=true
+EOF
+}
+
+if [[ "$MODE" == "check" ]]; then
+  status=0
+
+  check_same() {
+    local src="$1"
+    local dst="$2"
+    if [[ ! -f "$dst" ]] || ! cmp -s "$src" "$dst"; then
+      status=1
+    fi
+  }
+
+  check_same "$HELPER_SRC" "$INSTALL_DIR/HelperDaemon.py"
+  check_same "$WATCHDOG_SRC" "$INSTALL_DIR/WatchdogTimer.py"
+  check_same "$EC_SRC" "$INSTALL_DIR/ECController.py"
+  check_same "$EINK_SRC" "$INSTALL_DIR/EInkUSBController.py"
+  check_same "$SOCKET_UNIT_SRC" "/etc/systemd/system/tinta4plus-helper.socket"
+  check_same "$SERVICE_UNIT_SRC" "/etc/systemd/system/tinta4plus-helper.service"
+
+  tmp_desktop="$(mktemp)"
+  write_desktop_file "$(pick_icon_path)" "$tmp_desktop"
+  check_same "$tmp_desktop" "$DESKTOP_FILE"
+  rm -f "$tmp_desktop"
+
+  if ! getent group tinta4plus >/dev/null; then
+    status=1
+  fi
+
+  if [[ -n "$USER_NAME" ]] && ! id -nG "$USER_NAME" | tr ' ' '\n' | grep -qx tinta4plus; then
+    status=1
+  fi
+
+  if ! systemctl is-enabled tinta4plus-helper.socket >/dev/null 2>&1; then
+    status=1
+  fi
+
+  exit $status
+fi
+
+install -d -m 0755 "$INSTALL_DIR"
+install -m 0644 "$HELPER_SRC" "$INSTALL_DIR/HelperDaemon.py"
+install -m 0644 "$WATCHDOG_SRC" "$INSTALL_DIR/WatchdogTimer.py"
+install -m 0644 "$EC_SRC" "$INSTALL_DIR/ECController.py"
+install -m 0644 "$EINK_SRC" "$INSTALL_DIR/EInkUSBController.py"
+rm -f /usr/local/bin/HelperDaemon.py
+install -m 0644 "$SOCKET_UNIT_SRC" /etc/systemd/system/tinta4plus-helper.socket
+install -m 0644 "$SERVICE_UNIT_SRC" /etc/systemd/system/tinta4plus-helper.service
+write_desktop_file "$(pick_icon_path)" "$DESKTOP_FILE"
+chmod 0644 "$DESKTOP_FILE"
+
+if ! getent group tinta4plus >/dev/null; then
+  groupadd --system tinta4plus
+fi
+
+usermod -a -G tinta4plus "$USER_NAME"
+
+systemctl daemon-reload
+systemctl stop tinta4plus-helper.service tinta4plus-helper.socket 2>/dev/null || true
+systemctl reset-failed tinta4plus-helper.service tinta4plus-helper.socket 2>/dev/null || true
+rm -f /run/tinta4plus.sock /tmp/tinta4plus.pid
+systemctl enable --now tinta4plus-helper.socket
+systemctl restart tinta4plus-helper.socket
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+
+echo "Installed and enabled tinta4plus-helper.socket"
+echo "Installed desktop launcher: $DESKTOP_FILE"
+echo "User '$USER_NAME' added to group 'tinta4plus' (re-login may be required)."

--- a/tests/test_debug_display_switch_sensor.py
+++ b/tests/test_debug_display_switch_sensor.py
@@ -1,0 +1,70 @@
+import importlib.util
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "debug-display-switch-sensor.py"
+
+
+spec = importlib.util.spec_from_file_location("debug_display_switch_sensor", SCRIPT_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class DebugDisplaySwitchSensorTests(unittest.TestCase):
+    def test_find_tablet_mode_event_parses_handlers_line(self):
+        sample = '''I: Bus=0019 Vendor=0000 Product=0000 Version=0000
+N: Name="Lenovo Yoga Tablet Mode Control switch"
+P: Phys=06129D99-6083-4164-81AD-F092F9D773A6/input0
+S: Sysfs=/devices/platform/PNP0C14:01/wmi_bus/wmi_bus-PNP0C14:01/06129D99-6083-4164-81AD-F092F9D773A6/input/input25
+U: Uniq=
+H: Handlers=event14
+B: PROP=0
+B: EV=21
+B: SW=2
+'''
+        with tempfile.TemporaryDirectory() as td:
+            input_devices = Path(td) / "devices"
+            input_devices.write_text(sample, encoding="utf-8")
+            original = module.INPUT_DEVICES
+            module.INPUT_DEVICES = input_devices
+            try:
+                self.assertEqual(module.find_tablet_mode_event(), "/dev/input/event14")
+            finally:
+                module.INPUT_DEVICES = original
+
+    def test_normalize_deg_wraps_above_180(self):
+        self.assertEqual(module.normalize_deg(353.0), -7.0)
+        self.assertEqual(module.normalize_deg(180.0), 180.0)
+        self.assertEqual(module.normalize_deg(90.0), 90.0)
+        self.assertEqual(module.normalize_deg(360.0), 0.0)
+
+    def test_decode_input_event_extracts_type_code_value(self):
+        packed = struct.pack(
+            module.INPUT_EVENT_STRUCT.format,
+            0,
+            0,
+            module.EV_SW,
+            module.SW_TABLET_MODE,
+            1,
+        )
+        event_type, code, value = module.decode_input_event(packed)
+        self.assertEqual((event_type, code, value), (module.EV_SW, module.SW_TABLET_MODE, 1))
+
+    def test_format_input_event_detail_filters_syn(self):
+        self.assertIsNone(module.format_input_event_detail(module.EV_SYN, 0, 0))
+
+    def test_format_input_event_detail_formats_tablet_mode(self):
+        self.assertEqual(
+            module.format_input_event_detail(module.EV_SW, module.SW_TABLET_MODE, 1),
+            "SW_TABLET_MODE value=1 state=tablet",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from DisplayManager import DisplayManager
+
+
+class DisplayManagerRotationTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.manager = DisplayManager(self.logger)
+
+    def test_get_active_display_detects_connected_output_with_geometry(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 2880 x 1800, maximum 32767 x 32767
+eDP-1 connected primary 2880x1800+0+0 normal (normal left inverted right x axis y axis) 302mm x 189mm
+eDP-2 connected (normal left inverted right x axis y axis)
+""".strip()
+
+        with patch.object(self.manager, "_get_xrandr_output", return_value=xrandr_output):
+            active = self.manager.get_active_display()
+
+        self.assertEqual(active, "eDP-1")
+
+    def test_get_display_rotation_parses_normal_and_left(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1600 x 2560, maximum 32767 x 32767
+eDP-1 connected (normal left inverted right x axis y axis)
+eDP-2 connected primary 1600x2560+0+0 left (normal left inverted right x axis y axis)
+""".strip()
+
+        with patch.object(self.manager, "_get_xrandr_output", return_value=xrandr_output):
+            oled_rotation = self.manager.get_display_rotation("eDP-1")
+            eink_rotation = self.manager.get_display_rotation("eDP-2")
+
+        self.assertEqual(oled_rotation, "normal")
+        self.assertEqual(eink_rotation, "left")
+
+    def test_get_display_rotation_returns_none_for_unsupported_rotation(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1800 x 2880, maximum 32767 x 32767
+eDP-1 connected primary 1800x2880+0+0 right (normal left inverted right x axis y axis)
+""".strip()
+
+        with patch.object(self.manager, "_get_xrandr_output", return_value=xrandr_output):
+            rotation = self.manager.get_display_rotation("eDP-1")
+
+        self.assertIsNone(rotation)
+        self.logger.warning.assert_called_once()
+
+    def test_set_display_rotation_runs_xrandr_command_and_invalidates_cache(self):
+        self.manager._xrandr_cache = "cached"
+        self.manager._xrandr_cache_time = 123.0
+
+        with patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            ok = self.manager.set_display_rotation("eDP-2", "left")
+
+        self.assertTrue(ok)
+        run_mock.assert_called_once_with(
+            ["xrandr", "--output", "eDP-2", "--rotate", "left"],
+            capture_output=True,
+            timeout=self.manager.XRANDR_TIMEOUT,
+        )
+        self.assertIsNone(self.manager._xrandr_cache)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -63,6 +63,53 @@ eDP-1 connected primary 1800x2880+0+0 right (normal left inverted right x axis y
         )
         self.assertIsNone(self.manager._xrandr_cache)
 
+    def test_enable_display_lower_scale_resets_to_one_then_applies_target_scale(self):
+        with patch.object(self.manager, "get_effective_display_scale", return_value=1.9, create=True), \
+             patch.object(self.manager, "is_display_active", return_value=True), \
+             patch("DisplayManager.time.sleep"), \
+             patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            ok = self.manager.enable_display("eDP-1", scale=1.5)
+
+        self.assertTrue(ok)
+        self.assertEqual(run_mock.call_count, 2)
+
+        first_cmd = run_mock.call_args_list[0].args[0]
+        second_cmd = run_mock.call_args_list[1].args[0]
+
+        self.assertEqual(first_cmd[0:3], ["xrandr", "--output", "eDP-1"])
+        self.assertIn("--scale", first_cmd)
+        self.assertIn("1x1", first_cmd)
+
+        self.assertEqual(second_cmd[0:3], ["xrandr", "--output", "eDP-1"])
+        self.assertIn("--scale", second_cmd)
+        self.assertNotIn("1x1", second_cmd)
+
+    def test_enable_display_higher_scale_applies_once(self):
+        with patch.object(self.manager, "get_effective_display_scale", return_value=1.5, create=True), \
+             patch.object(self.manager, "is_display_active", return_value=True), \
+             patch("DisplayManager.time.sleep"), \
+             patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            ok = self.manager.enable_display("eDP-1", scale=1.9)
+
+        self.assertTrue(ok)
+        self.assertEqual(run_mock.call_count, 1)
+
+    def test_enable_display_unknown_current_scale_applies_once(self):
+        with patch.object(self.manager, "get_effective_display_scale", return_value=None, create=True), \
+             patch.object(self.manager, "is_display_active", return_value=True), \
+             patch("DisplayManager.time.sleep"), \
+             patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            ok = self.manager.enable_display("eDP-1", scale=1.5)
+
+        self.assertTrue(ok)
+        self.assertEqual(run_mock.call_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -63,9 +63,138 @@ eDP-1 connected primary 1800x2880+0+0 right (normal left inverted right x axis y
         )
         self.assertIsNone(self.manager._xrandr_cache)
 
-    def test_enable_display_lower_scale_resets_to_one_then_applies_target_scale(self):
-        with patch.object(self.manager, "get_effective_display_scale", return_value=1.9, create=True), \
-             patch.object(self.manager, "is_display_active", return_value=True), \
+
+class DisplayManagerTargetStateTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.manager = DisplayManager(self.logger)
+
+    def test_build_target_state_native_oled(self):
+        target = self.manager._build_display_target_state("eDP-1", 1.0)
+
+        self.assertEqual(target["display_name"], "eDP-1")
+        self.assertEqual(target["native_width"], 2880)
+        self.assertEqual(target["native_height"], 1800)
+        self.assertEqual(target["xrandr_scale_x"], 1.0)
+        self.assertEqual(target["xrandr_scale_y"], 1.0)
+        self.assertEqual(target["logical_width"], 2880)
+        self.assertEqual(target["logical_height"], 1800)
+        self.assertEqual(target["panning_width"], 2880)
+        self.assertEqual(target["panning_height"], 1800)
+        self.assertEqual(target["framebuffer_width"], 2880)
+        self.assertEqual(target["framebuffer_height"], 1800)
+
+    def test_build_target_state_scaled_oled(self):
+        target = self.manager._build_display_target_state("eDP-1", 1.5)
+
+        self.assertAlmostEqual(target["xrandr_scale_x"], 1 / 1.5)
+        self.assertAlmostEqual(target["xrandr_scale_y"], 1 / 1.5)
+        self.assertEqual(target["logical_width"], 1920)
+        self.assertEqual(target["logical_height"], 1200)
+        self.assertEqual(target["panning_width"], 1920)
+        self.assertEqual(target["panning_height"], 1200)
+        self.assertEqual(target["framebuffer_width"], 1920)
+        self.assertEqual(target["framebuffer_height"], 1200)
+
+    def test_build_target_state_scaled_eink(self):
+        target = self.manager._build_display_target_state("eDP-2", 1.75)
+
+        self.assertAlmostEqual(target["xrandr_scale_x"], 1 / 1.75)
+        self.assertAlmostEqual(target["xrandr_scale_y"], 1 / 1.75)
+        self.assertEqual(target["logical_width"], 1462)
+        self.assertEqual(target["logical_height"], 914)
+        self.assertEqual(target["panning_width"], 1462)
+        self.assertEqual(target["panning_height"], 914)
+        self.assertEqual(target["framebuffer_width"], 1462)
+        self.assertEqual(target["framebuffer_height"], 914)
+
+    def test_apply_display_scale_builds_full_state_xrandr_command(self):
+        with patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            ok = self.manager._apply_display_scale("eDP-1", scale=1.5)
+
+        self.assertTrue(ok)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[0:3], ["xrandr", "--output", "eDP-1"])
+        self.assertIn("--mode", command)
+        self.assertIn("2880x1800", command)
+        self.assertIn("--scale", command)
+        self.assertIn("0.6666666666666666x0.6666666666666666", command)
+        self.assertIn("--panning", command)
+        self.assertIn("1920x1200", command)
+        self.assertIn("--fb", command)
+        self.assertIn("1920x1200", command)
+
+    def test_apply_display_scale_unknown_display_uses_auto(self):
+        with patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            ok = self.manager._apply_display_scale("HDMI-9", scale=1.5)
+
+        self.assertTrue(ok)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[0:3], ["xrandr", "--output", "HDMI-9"])
+        self.assertIn("--auto", command)
+
+
+class DisplayManagerVerificationTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.manager = DisplayManager(self.logger)
+
+    def _target_state(self):
+        return {
+            "display_name": "eDP-2",
+            "logical_width": 1600,
+            "logical_height": 1000,
+            "framebuffer_width": 1600,
+            "framebuffer_height": 1000,
+        }
+
+    def test_verify_display_target_state_success(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1600 x 1000, maximum 32767 x 32767
+eDP-2 connected primary 1600x1000+0+0 normal (normal left inverted right x axis y axis)
+""".strip()
+
+        ok = self.manager._verify_display_target_state(
+            "eDP-2", self._target_state(), xrandr_output=xrandr_output
+        )
+
+        self.assertTrue(ok)
+
+    def test_verify_display_target_state_fails_when_framebuffer_too_small(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1500 x 900, maximum 32767 x 32767
+eDP-2 connected primary 1600x1000+0+0 normal (normal left inverted right x axis y axis)
+""".strip()
+
+        ok = self.manager._verify_display_target_state(
+            "eDP-2", self._target_state(), xrandr_output=xrandr_output
+        )
+
+        self.assertFalse(ok)
+
+    def test_verify_display_target_state_fails_when_output_geometry_wrong(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1600 x 1000, maximum 32767 x 32767
+eDP-2 connected primary 1400x900+0+0 normal (normal left inverted right x axis y axis)
+""".strip()
+
+        ok = self.manager._verify_display_target_state(
+            "eDP-2", self._target_state(), xrandr_output=xrandr_output
+        )
+
+        self.assertFalse(ok)
+
+
+class DisplayManagerRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.manager = DisplayManager(self.logger)
+
+    def test_enable_display_failed_verify_triggers_single_recovery_then_succeeds(self):
+        with patch.object(self.manager, "_verify_display_target_state", side_effect=[False, True]) as verify_mock, \
+             patch.object(self.manager, "_get_xrandr_output", return_value=None), \
              patch("DisplayManager.time.sleep"), \
              patch("DisplayManager.subprocess.run") as run_mock:
             run_mock.return_value.returncode = 0
@@ -73,56 +202,21 @@ eDP-1 connected primary 1800x2880+0+0 right (normal left inverted right x axis y
             ok = self.manager.enable_display("eDP-1", scale=1.5)
 
         self.assertTrue(ok)
-        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(verify_mock.call_count, 2)
+        self.assertEqual(run_mock.call_count, 3)
 
-        first_cmd = run_mock.call_args_list[0].args[0]
-        second_cmd = run_mock.call_args_list[1].args[0]
-
-        self.assertEqual(first_cmd[0:3], ["xrandr", "--output", "eDP-1"])
-        self.assertIn("--scale", first_cmd)
-        self.assertIn("1x1", first_cmd)
-
-        self.assertEqual(second_cmd[0:3], ["xrandr", "--output", "eDP-1"])
-        self.assertIn("--scale", second_cmd)
-        self.assertNotIn("1x1", second_cmd)
-
-    def test_enable_display_higher_scale_applies_once(self):
-        with patch.object(self.manager, "get_effective_display_scale", return_value=1.5, create=True), \
-             patch.object(self.manager, "is_display_active", return_value=True), \
-             patch("DisplayManager.time.sleep"), \
-             patch("DisplayManager.subprocess.run") as run_mock:
-            run_mock.return_value.returncode = 0
-
-            ok = self.manager.enable_display("eDP-1", scale=1.9)
-
-        self.assertTrue(ok)
-        self.assertEqual(run_mock.call_count, 1)
-
-    def test_enable_display_unknown_current_scale_applies_once(self):
-        with patch.object(self.manager, "get_effective_display_scale", return_value=None, create=True), \
-             patch.object(self.manager, "is_display_active", return_value=True), \
+    def test_enable_display_returns_false_when_recovery_verification_still_fails(self):
+        with patch.object(self.manager, "_verify_display_target_state", side_effect=[False, False]) as verify_mock, \
+             patch.object(self.manager, "_get_xrandr_output", return_value=None), \
              patch("DisplayManager.time.sleep"), \
              patch("DisplayManager.subprocess.run") as run_mock:
             run_mock.return_value.returncode = 0
 
             ok = self.manager.enable_display("eDP-1", scale=1.5)
 
-        self.assertTrue(ok)
-        self.assertEqual(run_mock.call_count, 1)
-
-    def test_enable_display_tolerates_nonzero_xrandr_when_output_becomes_active(self):
-        with patch.object(self.manager, "get_effective_display_scale", return_value=None, create=True), \
-             patch.object(self.manager, "is_display_active", return_value=True), \
-             patch("DisplayManager.time.sleep"), \
-             patch("DisplayManager.subprocess.run") as run_mock:
-            run_mock.return_value.returncode = 1
-            run_mock.return_value.stderr = b"X Error of failed request:  BadMatch"
-
-            ok = self.manager.enable_display("eDP-2", scale=1.75)
-
-        self.assertTrue(ok)
-        self.assertEqual(run_mock.call_count, 1)
-        self.logger.warning.assert_called()
+        self.assertFalse(ok)
+        self.assertEqual(verify_mock.call_count, 2)
+        self.assertEqual(run_mock.call_count, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -101,12 +101,12 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
 
         self.assertAlmostEqual(target["xrandr_scale_x"], 1 / 1.75)
         self.assertAlmostEqual(target["xrandr_scale_y"], 1 / 1.75)
-        self.assertEqual(target["logical_width"], 1462)
-        self.assertEqual(target["logical_height"], 914)
-        self.assertEqual(target["panning_width"], 1462)
-        self.assertEqual(target["panning_height"], 914)
-        self.assertEqual(target["framebuffer_width"], 1462)
-        self.assertEqual(target["framebuffer_height"], 914)
+        self.assertEqual(target["logical_width"], 1463)
+        self.assertEqual(target["logical_height"], 915)
+        self.assertEqual(target["panning_width"], 1463)
+        self.assertEqual(target["panning_height"], 915)
+        self.assertEqual(target["framebuffer_width"], 1463)
+        self.assertEqual(target["framebuffer_height"], 915)
 
     def test_apply_display_scale_builds_full_state_xrandr_command(self):
         with patch("DisplayManager.subprocess.run") as run_mock:
@@ -134,6 +134,25 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
         command = run_mock.call_args.args[0]
         self.assertEqual(command[0:3], ["xrandr", "--output", "HDMI-9"])
         self.assertIn("--auto", command)
+
+    def test_finalize_single_display_builds_compact_scaled_command(self):
+        with patch("DisplayManager.subprocess.run") as run_mock, \
+             patch.object(self.manager, "_verify_display_target_state", return_value=True), \
+             patch("DisplayManager.time.sleep"):
+            run_mock.return_value.returncode = 0
+            ok = self.manager.finalize_single_display("eDP-2", scale=1.75)
+
+        self.assertTrue(ok)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[0:3], ["xrandr", "--output", "eDP-2"])
+        self.assertIn("--mode", command)
+        self.assertIn("2560x1600", command)
+        self.assertIn("--scale", command)
+        self.assertIn("0.5714285714285714x0.5714285714285714", command)
+        self.assertIn("--panning", command)
+        self.assertIn("1463x915", command)
+        self.assertIn("--fb", command)
+        self.assertIn("1463x915", command)
 
 
 class DisplayManagerVerificationTests(unittest.TestCase):
@@ -186,14 +205,33 @@ eDP-2 connected primary 1400x900+0+0 normal (normal left inverted right x axis y
 
         self.assertFalse(ok)
 
+    def test_verify_display_target_state_succeeds_for_ceil_scaled_eink_layout(self):
+        target_state = {
+            "display_name": "eDP-2",
+            "logical_width": 1463,
+            "logical_height": 915,
+            "framebuffer_width": 1463,
+            "framebuffer_height": 915,
+        }
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1463 x 915, maximum 32767 x 32767
+eDP-2 connected primary 1463x915+0+0 normal (normal left inverted right x axis y axis)
+""".strip()
+
+        ok = self.manager._verify_display_target_state(
+            "eDP-2", target_state, xrandr_output=xrandr_output
+        )
+
+        self.assertTrue(ok)
+
 
 class DisplayManagerRecoveryTests(unittest.TestCase):
     def setUp(self):
         self.logger = MagicMock()
         self.manager = DisplayManager(self.logger)
 
-    def test_enable_display_failed_verify_triggers_single_recovery_then_succeeds(self):
-        with patch.object(self.manager, "_verify_display_target_state", side_effect=[False, True]) as verify_mock, \
+    def test_enable_display_uses_transition_safe_activation_without_fb_resize(self):
+        with patch.object(self.manager, "is_display_active", return_value=True), \
              patch.object(self.manager, "_get_xrandr_output", return_value=None), \
              patch("DisplayManager.time.sleep"), \
              patch("DisplayManager.subprocess.run") as run_mock:
@@ -202,11 +240,16 @@ class DisplayManagerRecoveryTests(unittest.TestCase):
             ok = self.manager.enable_display("eDP-1", scale=1.5)
 
         self.assertTrue(ok)
-        self.assertEqual(verify_mock.call_count, 2)
-        self.assertEqual(run_mock.call_count, 3)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[0:3], ["xrandr", "--output", "eDP-1"])
+        self.assertIn("--mode", command)
+        self.assertIn("2880x1800", command)
+        self.assertIn("--scale", command)
+        self.assertNotIn("--panning", command)
+        self.assertNotIn("--fb", command)
 
-    def test_enable_display_returns_false_when_recovery_verification_still_fails(self):
-        with patch.object(self.manager, "_verify_display_target_state", side_effect=[False, False]) as verify_mock, \
+    def test_enable_display_returns_false_when_output_not_active_after_apply(self):
+        with patch.object(self.manager, "is_display_active", return_value=False), \
              patch.object(self.manager, "_get_xrandr_output", return_value=None), \
              patch("DisplayManager.time.sleep"), \
              patch("DisplayManager.subprocess.run") as run_mock:
@@ -215,8 +258,6 @@ class DisplayManagerRecoveryTests(unittest.TestCase):
             ok = self.manager.enable_display("eDP-1", scale=1.5)
 
         self.assertFalse(ok)
-        self.assertEqual(verify_mock.call_count, 2)
-        self.assertEqual(run_mock.call_count, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -198,6 +198,25 @@ eDP-2 connected primary 1600x1000+0+0 normal (normal left inverted right x axis 
 
         self.assertFalse(ok)
 
+    def test_verify_display_target_state_succeeds_when_framebuffer_exceeds_output_geometry(self):
+        xrandr_output = """
+Screen 0: minimum 8 x 8, current 1800 x 1125, maximum 32767 x 32767
+eDP-2 connected primary 1463x915+0+0 normal (normal left inverted right x axis y axis)
+""".strip()
+        target_state = {
+            "display_name": "eDP-2",
+            "logical_width": 1463,
+            "logical_height": 915,
+            "framebuffer_width": 1463,
+            "framebuffer_height": 915,
+        }
+
+        ok = self.manager._verify_display_target_state(
+            "eDP-2", target_state, xrandr_output=xrandr_output
+        )
+
+        self.assertTrue(ok)
+
     def test_verify_display_target_state_fails_when_output_geometry_wrong(self):
         xrandr_output = """
 Screen 0: minimum 8 x 8, current 1600 x 1000, maximum 32767 x 32767
@@ -234,6 +253,27 @@ class DisplayManagerRecoveryTests(unittest.TestCase):
     def setUp(self):
         self.logger = MagicMock()
         self.manager = DisplayManager(self.logger)
+
+    def test_finalize_single_display_retries_once_after_native_baseline_reset(self):
+        with patch.object(self.manager, "_apply_display_target_state", return_value=True) as apply_target, \
+             patch.object(self.manager, "_reset_display_to_native_baseline", return_value=True) as reset_baseline, \
+             patch.object(self.manager, "_verify_display_target_state", side_effect=[False, True]), \
+             patch("DisplayManager.time.sleep"):
+            ok = self.manager.finalize_single_display("eDP-1", scale=1.75)
+
+        self.assertTrue(ok)
+        reset_baseline.assert_called_once_with("eDP-1")
+        self.assertEqual(apply_target.call_count, 2)
+
+    def test_finalize_single_display_returns_false_when_retry_still_fails(self):
+        with patch.object(self.manager, "_apply_display_target_state", return_value=True), \
+             patch.object(self.manager, "_reset_display_to_native_baseline", return_value=True) as reset_baseline, \
+             patch.object(self.manager, "_verify_display_target_state", side_effect=[False, False]), \
+             patch("DisplayManager.time.sleep"):
+            ok = self.manager.finalize_single_display("eDP-1", scale=1.75)
+
+        self.assertFalse(ok)
+        reset_baseline.assert_called_once_with("eDP-1")
 
     def test_enable_display_uses_transition_safe_activation_without_fb_resize(self):
         with patch.object(self.manager, "is_display_active", return_value=True), \

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -110,6 +110,20 @@ eDP-1 connected primary 1800x2880+0+0 right (normal left inverted right x axis y
         self.assertTrue(ok)
         self.assertEqual(run_mock.call_count, 1)
 
+    def test_enable_display_tolerates_nonzero_xrandr_when_output_becomes_active(self):
+        with patch.object(self.manager, "get_effective_display_scale", return_value=None, create=True), \
+             patch.object(self.manager, "is_display_active", return_value=True), \
+             patch("DisplayManager.time.sleep"), \
+             patch("DisplayManager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 1
+            run_mock.return_value.stderr = b"X Error of failed request:  BadMatch"
+
+            ok = self.manager.enable_display("eDP-2", scale=1.75)
+
+        self.assertTrue(ok)
+        self.assertEqual(run_mock.call_count, 1)
+        self.logger.warning.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_display_manager_rotation.py
+++ b/tests/test_display_manager_rotation.py
@@ -64,7 +64,7 @@ eDP-1 connected primary 1800x2880+0+0 right (normal left inverted right x axis y
         self.assertIsNone(self.manager._xrandr_cache)
 
 
-class DisplayManagerTargetStateTests(unittest.TestCase):
+class DisplayManagerScalingTests(unittest.TestCase):
     def setUp(self):
         self.logger = MagicMock()
         self.manager = DisplayManager(self.logger)
@@ -75,8 +75,9 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
         self.assertEqual(target["display_name"], "eDP-1")
         self.assertEqual(target["native_width"], 2880)
         self.assertEqual(target["native_height"], 1800)
-        self.assertEqual(target["xrandr_scale_x"], 1.0)
-        self.assertEqual(target["xrandr_scale_y"], 1.0)
+        self.assertEqual(target["transform_scale_x"], 1.0)
+        self.assertEqual(target["transform_scale_y"], 1.0)
+        self.assertEqual(target["transform_matrix"], "1,0,0,0,1,0,0,0,1")
         self.assertEqual(target["logical_width"], 2880)
         self.assertEqual(target["logical_height"], 1800)
         self.assertEqual(target["panning_width"], 2880)
@@ -87,8 +88,9 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
     def test_build_target_state_scaled_oled(self):
         target = self.manager._build_display_target_state("eDP-1", 1.5)
 
-        self.assertAlmostEqual(target["xrandr_scale_x"], 1 / 1.5)
-        self.assertAlmostEqual(target["xrandr_scale_y"], 1 / 1.5)
+        self.assertAlmostEqual(target["transform_scale_x"], 1 / 1.5)
+        self.assertAlmostEqual(target["transform_scale_y"], 1 / 1.5)
+        self.assertEqual(target["transform_matrix"], "0.6666666666666666,0,0,0,0.6666666666666666,0,0,0,1")
         self.assertEqual(target["logical_width"], 1920)
         self.assertEqual(target["logical_height"], 1200)
         self.assertEqual(target["panning_width"], 1920)
@@ -99,8 +101,9 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
     def test_build_target_state_scaled_eink(self):
         target = self.manager._build_display_target_state("eDP-2", 1.75)
 
-        self.assertAlmostEqual(target["xrandr_scale_x"], 1 / 1.75)
-        self.assertAlmostEqual(target["xrandr_scale_y"], 1 / 1.75)
+        self.assertAlmostEqual(target["transform_scale_x"], 1 / 1.75)
+        self.assertAlmostEqual(target["transform_scale_y"], 1 / 1.75)
+        self.assertEqual(target["transform_matrix"], "0.5714285714285714,0,0,0,0.5714285714285714,0,0,0,1")
         self.assertEqual(target["logical_width"], 1463)
         self.assertEqual(target["logical_height"], 915)
         self.assertEqual(target["panning_width"], 1463)
@@ -118,8 +121,9 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
         self.assertEqual(command[0:3], ["xrandr", "--output", "eDP-1"])
         self.assertIn("--mode", command)
         self.assertIn("2880x1800", command)
-        self.assertIn("--scale", command)
-        self.assertIn("0.6666666666666666x0.6666666666666666", command)
+        self.assertIn("--transform", command)
+        self.assertIn("0.6666666666666666,0,0,0,0.6666666666666666,0,0,0,1", command)
+        self.assertNotIn("--scale", command)
         self.assertIn("--panning", command)
         self.assertIn("1920x1200", command)
         self.assertIn("--fb", command)
@@ -147,8 +151,9 @@ class DisplayManagerTargetStateTests(unittest.TestCase):
         self.assertEqual(command[0:3], ["xrandr", "--output", "eDP-2"])
         self.assertIn("--mode", command)
         self.assertIn("2560x1600", command)
-        self.assertIn("--scale", command)
-        self.assertIn("0.5714285714285714x0.5714285714285714", command)
+        self.assertIn("--transform", command)
+        self.assertIn("0.5714285714285714,0,0,0,0.5714285714285714,0,0,0,1", command)
+        self.assertNotIn("--scale", command)
         self.assertIn("--panning", command)
         self.assertIn("1463x915", command)
         self.assertIn("--fb", command)
@@ -244,7 +249,9 @@ class DisplayManagerRecoveryTests(unittest.TestCase):
         self.assertEqual(command[0:3], ["xrandr", "--output", "eDP-1"])
         self.assertIn("--mode", command)
         self.assertIn("2880x1800", command)
-        self.assertIn("--scale", command)
+        self.assertIn("--transform", command)
+        self.assertIn("0.6666666666666666,0,0,0,0.6666666666666666,0,0,0,1", command)
+        self.assertNotIn("--scale", command)
         self.assertNotIn("--panning", command)
         self.assertNotIn("--fb", command)
 

--- a/tests/test_helper_daemon_http.py
+++ b/tests/test_helper_daemon_http.py
@@ -1,0 +1,60 @@
+import json
+import unittest
+from unittest.mock import Mock
+
+from HelperDaemon import HelperDaemon
+
+
+class HelperDaemonHTTPTests(unittest.TestCase):
+    def test_post_v1_eink_refresh_maps_to_refresh_command(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+        daemon.handle_command = lambda cmd: {"success": True, "echo": cmd["command"]}
+
+        status, payload = daemon.handle_http_request("POST", "/v1/eink/refresh", b"{}")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"success": True, "echo": "refresh-eink"})
+
+    def test_invalid_json_returns_400(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+
+        status, payload = daemon.handle_http_request("POST", "/v1/eink/refresh", b"{")
+
+        self.assertEqual(status, 400)
+        self.assertFalse(payload["success"])
+        self.assertIn("Invalid JSON", payload["error"])
+
+    def test_unknown_route_returns_404(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+
+        status, payload = daemon.handle_http_request("POST", "/v1/nope", b"{}")
+
+        self.assertEqual(status, 404)
+        self.assertFalse(payload["success"])
+
+    def test_wrong_method_returns_405(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+
+        status, payload = daemon.handle_http_request("GET", "/v1/eink/refresh", b"")
+
+        self.assertEqual(status, 405)
+        self.assertFalse(payload["success"])
+
+    def test_access_log_includes_method_path_status_and_ms(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+        daemon.handle_command = lambda cmd: {"success": True}
+
+        daemon.handle_http_request("POST", "/v1/eink/refresh", b"{}")
+
+        log_messages = "\n".join(str(c.args[0]) for c in logger.info.call_args_list)
+        self.assertIn('HTTP unix-client "POST /v1/eink/refresh" 200', log_messages)
+        self.assertIn("ms", log_messages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_helper_daemon_http.py
+++ b/tests/test_helper_daemon_http.py
@@ -6,6 +6,33 @@ from HelperDaemon import HelperDaemon
 
 
 class HelperDaemonHTTPTests(unittest.TestCase):
+    def test_set_brightness_level_zero_disables_frontlight(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+        daemon.ec = Mock()
+        daemon.ec.access_available = True
+        daemon.ec.disable_frontlight.return_value = (True, 0x05)
+
+        payload = daemon.handle_command({"command": "set-brightness", "params": {"level": 0}})
+
+        self.assertTrue(payload["success"])
+        daemon.ec.disable_frontlight.assert_called_once_with()
+        daemon.ec.set_brightness.assert_not_called()
+
+    def test_set_brightness_positive_enables_then_sets_brightness(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+        daemon.ec = Mock()
+        daemon.ec.access_available = True
+        daemon.ec.enable_frontlight.return_value = (True, 0x06)
+        daemon.ec.set_brightness.return_value = (True, 0x04)
+
+        payload = daemon.handle_command({"command": "set-brightness", "params": {"level": 1}})
+
+        self.assertTrue(payload["success"])
+        daemon.ec.enable_frontlight.assert_called_once_with()
+        daemon.ec.set_brightness.assert_called_once_with(1)
+
     def test_post_v1_eink_refresh_maps_to_refresh_command(self):
         logger = Mock()
         daemon = HelperDaemon(logger)

--- a/tests/test_http_unix_socket_protocol.py
+++ b/tests/test_http_unix_socket_protocol.py
@@ -1,0 +1,90 @@
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from HelperClient import HelperClient
+
+
+class FakeHTTPResponse:
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self._payload = payload or {"success": True}
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+class FakeHTTPConnection:
+    last_request = None
+    response = FakeHTTPResponse()
+
+    def __init__(self, socket_path, timeout=10.0):
+        self.socket_path = socket_path
+        self.timeout = timeout
+
+    def request(self, method, url, body=None, headers=None):
+        FakeHTTPConnection.last_request = {
+            "method": method,
+            "url": url,
+            "body": body,
+            "headers": headers or {},
+        }
+
+    def getresponse(self):
+        return FakeHTTPConnection.response
+
+    def close(self):
+        pass
+
+
+class HTTPUnixSocketClientTests(unittest.TestCase):
+    @patch("HelperClient.UnixSocketHTTPConnection", FakeHTTPConnection)
+    def test_refresh_eink_maps_to_post_v1_eink_refresh(self):
+        logger = Mock()
+        client = HelperClient(logger)
+        client.connected = True
+        client.socket_path = "/run/tinta4plus.sock"
+        client.socket = object()
+
+        FakeHTTPConnection.response = FakeHTTPResponse(status=200, payload={"success": True, "message": "ok"})
+        result = client.send_command("refresh-eink")
+
+        self.assertTrue(result["success"])
+        req = FakeHTTPConnection.last_request
+        self.assertEqual(req["method"], "POST")
+        self.assertEqual(req["url"], "/v1/eink/refresh")
+        self.assertEqual(json.loads(req["body"].decode("utf-8")), {})
+        self.assertEqual(req["headers"].get("Content-Type"), "application/json")
+
+    @patch("HelperClient.UnixSocketHTTPConnection", FakeHTTPConnection)
+    def test_set_brightness_uses_v1_frontlight_brightness_payload(self):
+        logger = Mock()
+        client = HelperClient(logger)
+        client.connected = True
+        client.socket_path = "/run/tinta4plus.sock"
+        client.socket = object()
+
+        FakeHTTPConnection.response = FakeHTTPResponse(status=200, payload={"success": True})
+        client.send_command("set-brightness", level=80)
+
+        req = FakeHTTPConnection.last_request
+        self.assertEqual(req["method"], "POST")
+        self.assertEqual(req["url"], "/v1/frontlight/brightness")
+        self.assertEqual(json.loads(req["body"].decode("utf-8")), {"level": 80})
+
+    @patch("HelperClient.UnixSocketHTTPConnection", FakeHTTPConnection)
+    def test_non_200_response_raises_runtime_error(self):
+        logger = Mock()
+        client = HelperClient(logger)
+        client.connected = True
+        client.socket_path = "/run/tinta4plus.sock"
+        client.socket = object()
+
+        FakeHTTPConnection.response = FakeHTTPResponse(status=404, payload={"success": False, "error": "not found"})
+
+        with self.assertRaises(RuntimeError):
+            client.send_command("refresh-eink")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logging_targets.py
+++ b/tests/test_logging_targets.py
@@ -15,6 +15,12 @@ class LoggingTargetsTests(unittest.TestCase):
         file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
         self.assertEqual(logger.name, "tinta4plus-gui")
 
+    def test_tinta_setup_logger_survives_permission_error_on_log_file(self):
+        with patch.object(Tinta4Plus.logging, "FileHandler", side_effect=PermissionError("denied")):
+            logger = Tinta4Plus.setup_logger()
+
+        self.assertEqual(logger.name, "tinta4plus-gui")
+
     def test_toggle_setup_logger_writes_to_helper_log_file(self):
         toggle_path = Path(__file__).resolve().parents[1] / "toggle-eink.py"
         spec = importlib.util.spec_from_file_location("toggle_eink_module", toggle_path)
@@ -28,17 +34,36 @@ class LoggingTargetsTests(unittest.TestCase):
         file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
         self.assertEqual(logger.name, "toggle-eink")
 
-    def test_helper_main_uses_append_mode_for_helper_log_file(self):
+    def test_toggle_setup_logger_survives_permission_error_on_log_file(self):
+        toggle_path = Path(__file__).resolve().parents[1] / "toggle-eink.py"
+        spec = importlib.util.spec_from_file_location("toggle_eink_module", toggle_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with patch.object(module.logging, "FileHandler", side_effect=PermissionError("denied")):
+            logger = module.setup_logger()
+
+        self.assertEqual(logger.name, "toggle-eink")
+
+    def test_helper_main_uses_stream_logging_only(self):
         with patch.object(HelperDaemon.os, "geteuid", return_value=0), \
+             patch.object(HelperDaemon.logging, "StreamHandler") as stream_handler_cls, \
              patch.object(HelperDaemon.logging, "FileHandler") as file_handler_cls, \
+             patch.object(HelperDaemon.logging, "basicConfig") as basic_config, \
              patch.object(HelperDaemon.logging, "getLogger") as get_logger, \
              patch.object(HelperDaemon, "HelperDaemon") as daemon_cls:
+            stream_handler = unittest.mock.MagicMock()
+            stream_handler_cls.return_value = stream_handler
             get_logger.return_value = unittest.mock.MagicMock()
             daemon_cls.return_value.run.return_value = 0
             rc = HelperDaemon.main()
 
         self.assertEqual(rc, 0)
-        file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
+        file_handler_cls.assert_not_called()
+        basic_config.assert_called_once()
+        _, kwargs = basic_config.call_args
+        self.assertEqual(kwargs["handlers"], [stream_handler])
 
 
 if __name__ == "__main__":

--- a/tests/test_logging_targets.py
+++ b/tests/test_logging_targets.py
@@ -1,0 +1,32 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import Tinta4Plus
+
+
+class LoggingTargetsTests(unittest.TestCase):
+    def test_tinta_setup_logger_writes_to_helper_log_file(self):
+        with patch.object(Tinta4Plus.logging, "FileHandler") as file_handler_cls:
+            logger = Tinta4Plus.setup_logger()
+
+        file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
+        self.assertEqual(logger.name, "tinta4plus-gui")
+
+    def test_toggle_setup_logger_writes_to_helper_log_file(self):
+        toggle_path = Path(__file__).resolve().parents[1] / "toggle-eink.py"
+        spec = importlib.util.spec_from_file_location("toggle_eink_module", toggle_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with patch.object(module.logging, "FileHandler") as file_handler_cls:
+            logger = module.setup_logger()
+
+        file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
+        self.assertEqual(logger.name, "toggle-eink")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logging_targets.py
+++ b/tests/test_logging_targets.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import HelperDaemon
 import Tinta4Plus
 
 
@@ -26,6 +27,18 @@ class LoggingTargetsTests(unittest.TestCase):
 
         file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
         self.assertEqual(logger.name, "toggle-eink")
+
+    def test_helper_main_uses_append_mode_for_helper_log_file(self):
+        with patch.object(HelperDaemon.os, "geteuid", return_value=0), \
+             patch.object(HelperDaemon.logging, "FileHandler") as file_handler_cls, \
+             patch.object(HelperDaemon.logging, "getLogger") as get_logger, \
+             patch.object(HelperDaemon, "HelperDaemon") as daemon_cls:
+            get_logger.return_value = unittest.mock.MagicMock()
+            daemon_cls.return_value.run.return_value = 0
+            rc = HelperDaemon.main()
+
+        self.assertEqual(rc, 0)
+        file_handler_cls.assert_called_once_with("/tmp/TintaHelper.log", mode="a")
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_input_mode.py
+++ b/tests/test_mode_switch_input_mode.py
@@ -1,3 +1,4 @@
+import subprocess
 import unittest
 from unittest.mock import MagicMock, call, patch
 
@@ -13,6 +14,86 @@ class ApplyInputModeTests(unittest.TestCase):
             {"id": 21, "name": "Wacom HID 537D Pen stylus"},
             {"id": 22, "name": "Wacom HID 537D Finger touch"},
         ]
+
+    def test_run_xinput_logs_command_and_success(self):
+        completed = subprocess.CompletedProcess(
+            ["xinput", "enable", "13"],
+            0,
+            stdout="done\n",
+            stderr="",
+        )
+
+        with patch.object(mode_switch.subprocess, "run", return_value=completed):
+            output = mode_switch._run_xinput(self.logger, ["enable", "13"])
+
+        self.assertEqual(output, "done\n")
+        self.logger.info.assert_has_calls([
+            call("Running xinput enable 13"),
+            call("xinput enable 13 succeeded: done"),
+        ])
+
+    def test_run_xinput_logs_detailed_failure(self):
+        error = subprocess.CalledProcessError(
+            1,
+            ["xinput", "map-to-output", "13", "eDP-2"],
+            output="partial stdout",
+            stderr="bad things",
+        )
+
+        with patch.object(mode_switch.subprocess, "run", side_effect=error):
+            output = mode_switch._run_xinput(self.logger, ["map-to-output", "13", "eDP-2"])
+
+        self.assertIsNone(output)
+        self.logger.info.assert_called_once_with("Running xinput map-to-output 13 eDP-2")
+        self.logger.warning.assert_called_once_with(
+            "xinput map-to-output 13 eDP-2 failed (rc=1): stderr=bad things; stdout=partial stdout"
+        )
+
+    def test_list_xinput_devices_normalizes_floating_prefixes(self):
+        output = (
+            "∼ ITE Tech. Inc. ITE T-CON                \tid=13\t[floating slave]\n"
+            "⎜   ↳ Wacom HID 537D Finger touch          \tid=18\t[slave  pointer  (2)]\n"
+        )
+
+        with patch.object(mode_switch, "_run_xinput", return_value=output):
+            devices = mode_switch._list_xinput_devices(self.logger)
+
+        self.assertEqual(devices, [
+            {"id": 13, "name": "ITE Tech. Inc. ITE T-CON"},
+            {"id": 18, "name": "Wacom HID 537D Finger touch"},
+        ])
+
+    def test_expected_touch_ids_for_eink_target_uses_ite_devices(self):
+        expected_ids = mode_switch._expected_touch_ids_for_target(self.devices, "eink")
+
+        self.assertEqual(expected_ids, [13, 14])
+
+    def test_expected_touch_ids_for_oled_target_uses_wacom_devices(self):
+        expected_ids = mode_switch._expected_touch_ids_for_target(self.devices, "oled")
+
+        self.assertEqual(expected_ids, [21, 22])
+
+    def test_touch_health_is_healthy_when_any_expected_device_is_enabled(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices), \
+             patch.object(mode_switch, "_get_device_enabled_state", side_effect=[0, 1]) as enabled_state:
+            healthy = mode_switch._is_touch_healthy_for_target(self.logger, "eink")
+
+        self.assertTrue(healthy)
+        enabled_state.assert_has_calls([
+            call(self.logger, 13),
+            call(self.logger, 14),
+        ])
+
+    def test_touch_health_is_busted_when_all_expected_devices_are_disabled(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices), \
+             patch.object(mode_switch, "_get_device_enabled_state", side_effect=[0, 0]) as enabled_state:
+            healthy = mode_switch._is_touch_healthy_for_target(self.logger, "eink")
+
+        self.assertFalse(healthy)
+        enabled_state.assert_has_calls([
+            call(self.logger, 13),
+            call(self.logger, 14),
+        ])
 
     def test_apply_input_mode_eink_enables_ite_disables_wacom_and_maps_to_eink_output(self):
         with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices) as list_devices, \
@@ -53,6 +134,21 @@ class ApplyInputModeTests(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def test_apply_input_mode_logs_summary(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices), \
+             patch.object(mode_switch, "_set_input_enabled", return_value=True), \
+             patch.object(mode_switch, "_map_input_to_output", return_value=True, create=True):
+            result = mode_switch._apply_input_mode(self.logger, "eink")
+
+        self.assertTrue(result)
+        self.logger.info.assert_any_call(
+            "Input mode eink: matched E-Ink devices [13, 14], OLED devices [21, 22]"
+        )
+        self.logger.info.assert_any_call(
+            "Input mode eink: target_output=eDP-2 enable_ids=[13, 14] disable_ids=[21, 22]"
+        )
+        self.logger.info.assert_any_call("Input mode eink applied successfully")
+
     def test_apply_input_mode_returns_false_when_no_devices_found(self):
         with patch.object(mode_switch, "_list_xinput_devices", return_value=[]), \
              patch.object(mode_switch, "_set_input_enabled") as set_enabled, \
@@ -63,6 +159,42 @@ class ApplyInputModeTests(unittest.TestCase):
         set_enabled.assert_not_called()
         map_output.assert_not_called()
         self.logger.warning.assert_called_once_with("No xinput devices found; skipping input mode update")
+
+    def test_ensure_touch_available_does_nothing_when_touch_is_healthy(self):
+        with patch.object(mode_switch, "_is_touch_healthy_for_target", return_value=True) as healthy, \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode:
+            ok = mode_switch.ensure_touch_available(self.logger, "eink")
+
+        self.assertTrue(ok)
+        healthy.assert_called_once_with(self.logger, "eink")
+        apply_input_mode.assert_not_called()
+
+    def test_ensure_touch_available_reapplies_input_mode_when_touch_is_busted(self):
+        with patch.object(mode_switch, "_is_touch_healthy_for_target", side_effect=[False, True]), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode:
+            ok = mode_switch.ensure_touch_available(self.logger, "eink")
+
+        self.assertTrue(ok)
+        apply_input_mode.assert_called_once_with(self.logger, "eink")
+
+    def test_ensure_touch_available_verifies_again_after_reapply(self):
+        with patch.object(mode_switch, "_is_touch_healthy_for_target", side_effect=[False, True]) as healthy, \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True):
+            mode_switch.ensure_touch_available(self.logger, "oled")
+
+        self.assertEqual(healthy.call_count, 2)
+        healthy.assert_has_calls([
+            call(self.logger, "oled"),
+            call(self.logger, "oled"),
+        ])
+
+    def test_ensure_touch_available_logs_warning_when_touch_stays_busted(self):
+        with patch.object(mode_switch, "_is_touch_healthy_for_target", side_effect=[False, False]), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True):
+            ok = mode_switch.ensure_touch_available(self.logger, "eink")
+
+        self.assertFalse(ok)
+        self.logger.warning.assert_any_call("Touch still unavailable for eink after input remap retry")
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_input_mode.py
+++ b/tests/test_mode_switch_input_mode.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import mode_switch
+
+
+class ApplyInputModeTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.devices = [
+            {"id": 13, "name": "ITE Tech. Inc. ITE T-CON Pen stylus"},
+            {"id": 14, "name": "ITE Tech. Inc. ITE T-CON Finger touch"},
+            {"id": 21, "name": "Wacom HID 537D Pen stylus"},
+            {"id": 22, "name": "Wacom HID 537D Finger touch"},
+        ]
+
+    def test_apply_input_mode_eink_enables_ite_disables_wacom_and_maps_to_eink_output(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices) as list_devices, \
+             patch.object(mode_switch, "_set_input_enabled", return_value=True) as set_enabled, \
+             patch.object(mode_switch, "_map_input_to_output", return_value=True, create=True) as map_output:
+            result = mode_switch._apply_input_mode(self.logger, "eink")
+
+        self.assertTrue(result)
+        list_devices.assert_called_once_with(self.logger)
+        set_enabled.assert_has_calls([
+            call(self.logger, 13, True),
+            call(self.logger, 14, True),
+            call(self.logger, 21, False),
+            call(self.logger, 22, False),
+        ])
+        map_output.assert_has_calls([
+            call(self.logger, 13, mode_switch.DISPLAY_EINK),
+            call(self.logger, 14, mode_switch.DISPLAY_EINK),
+        ])
+
+    def test_apply_input_mode_oled_maps_enabled_wacom_devices_to_oled_output(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices), \
+             patch.object(mode_switch, "_set_input_enabled", return_value=True), \
+             patch.object(mode_switch, "_map_input_to_output", return_value=True, create=True) as map_output:
+            result = mode_switch._apply_input_mode(self.logger, "oled")
+
+        self.assertTrue(result)
+        map_output.assert_has_calls([
+            call(self.logger, 21, mode_switch.DISPLAY_OLED),
+            call(self.logger, 22, mode_switch.DISPLAY_OLED),
+        ])
+
+    def test_apply_input_mode_returns_false_when_mapping_fails(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=self.devices), \
+             patch.object(mode_switch, "_set_input_enabled", return_value=True), \
+             patch.object(mode_switch, "_map_input_to_output", side_effect=[False, True], create=True):
+            result = mode_switch._apply_input_mode(self.logger, "eink")
+
+        self.assertFalse(result)
+
+    def test_apply_input_mode_returns_false_when_no_devices_found(self):
+        with patch.object(mode_switch, "_list_xinput_devices", return_value=[]), \
+             patch.object(mode_switch, "_set_input_enabled") as set_enabled, \
+             patch.object(mode_switch, "_map_input_to_output", create=True) as map_output:
+            result = mode_switch._apply_input_mode(self.logger, "eink")
+
+        self.assertFalse(result)
+        set_enabled.assert_not_called()
+        map_output.assert_not_called()
+        self.logger.warning.assert_called_once_with("No xinput devices found; skipping input mode update")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mode_switch_input_mode.py
+++ b/tests/test_mode_switch_input_mode.py
@@ -197,5 +197,57 @@ class ApplyInputModeTests(unittest.TestCase):
         self.logger.warning.assert_any_call("Touch still unavailable for eink after input remap retry")
 
 
+class TouchReconcilerTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.display_mgr = MagicMock()
+
+    def test_reconcile_touch_with_explicit_target_delegates_to_ensure_touch_available(self):
+        with patch.object(mode_switch, "ensure_touch_available", return_value=True) as ensure_touch:
+            ok = mode_switch.reconcile_touch(self.logger, self.display_mgr, target="eink", reason="switch")
+
+        self.assertTrue(ok)
+        ensure_touch.assert_called_once_with(self.logger, "eink")
+
+    def test_reconcile_touch_without_target_derives_target_from_live_mode(self):
+        with patch.object(mode_switch, "get_display_state", return_value={"mode": "oled"}) as get_state, \
+             patch.object(mode_switch, "ensure_touch_available", return_value=True) as ensure_touch:
+            ok = mode_switch.reconcile_touch(self.logger, self.display_mgr, reason="activation")
+
+        self.assertTrue(ok)
+        get_state.assert_called_once_with(self.display_mgr)
+        ensure_touch.assert_called_once_with(self.logger, "oled")
+
+    def test_reconcile_touch_skips_when_live_mode_is_mixed_or_unknown(self):
+        for mode in ("mixed", "unknown"):
+            with self.subTest(mode=mode):
+                self.logger.reset_mock()
+                with patch.object(mode_switch, "get_display_state", return_value={"mode": mode}), \
+                     patch.object(mode_switch, "ensure_touch_available", return_value=True) as ensure_touch:
+                    ok = mode_switch.reconcile_touch(self.logger, self.display_mgr, reason="activation")
+
+                self.assertFalse(ok)
+                ensure_touch.assert_not_called()
+
+    def test_reconcile_touch_logs_reason_for_success_skip_and_failure(self):
+        with patch.object(mode_switch, "ensure_touch_available", return_value=True):
+            ok_success = mode_switch.reconcile_touch(self.logger, self.display_mgr, target="eink", reason="switch-ok")
+
+        with patch.object(mode_switch, "get_display_state", return_value={"mode": "mixed"}), \
+             patch.object(mode_switch, "ensure_touch_available", return_value=True):
+            ok_skip = mode_switch.reconcile_touch(self.logger, self.display_mgr, reason="skip-path")
+
+        with patch.object(mode_switch, "ensure_touch_available", return_value=False):
+            ok_failure = mode_switch.reconcile_touch(self.logger, self.display_mgr, target="oled", reason="switch-fail")
+
+        self.assertTrue(ok_success)
+        self.assertFalse(ok_skip)
+        self.assertFalse(ok_failure)
+
+        self.logger.info.assert_any_call("Touch reconcile succeeded (reason=switch-ok, target=eink)")
+        self.logger.info.assert_any_call("Touch reconcile skipped (reason=skip-path, mode=mixed)")
+        self.logger.warning.assert_any_call("Touch reconcile failed (reason=switch-fail, target=oled)")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mode_switch_power_policy.py
+++ b/tests/test_mode_switch_power_policy.py
@@ -1,0 +1,173 @@
+import subprocess
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import mode_switch
+
+
+XSET_OUTPUT = """
+Keyboard Control:
+  auto repeat:  on    key click percent:  0    LED mask:  00000000
+Screen Saver:
+  prefer blanking:  yes    allow exposures:  yes
+  timeout:  300    cycle:  300
+DPMS (Energy Star):
+  Standby: 120    Suspend: 0    Off: 600
+  DPMS is Enabled
+"""
+
+
+class DisplayPowerPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+
+    def _completed(self, stdout=""):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def test_capture_display_power_state_includes_xset_screensaver_and_dpms(self):
+        def fake_run(cmd, **kwargs):
+            self.assertEqual(cmd, ["xset", "q"])
+            return self._completed(XSET_OUTPUT)
+
+        with patch.object(mode_switch.subprocess, "run", side_effect=fake_run):
+            state = mode_switch._capture_display_power_state(self.logger)
+
+        self.assertEqual(
+            state["xset"],
+            {
+                "screensaver_timeout": 300,
+                "screensaver_cycle": 300,
+                "dpms_enabled": True,
+                "dpms_standby": 120,
+                "dpms_suspend": 0,
+                "dpms_off": 600,
+            },
+        )
+
+    def test_disable_for_eink_saves_once_and_disables_xset_and_xfce_blanking(self):
+        saved_settings = {}
+        xfce_values = {
+            "/xfce4-power-manager/dpms-enabled": "true\n",
+            "/xfce4-power-manager/blank-on-ac": "10\n",
+            "/xfce4-power-manager/blank-on-battery": "1\n",
+            "/xfce4-power-manager/dpms-on-ac-sleep": "2\n",
+            "/xfce4-power-manager/dpms-on-ac-off": "10\n",
+            "/xfce4-power-manager/pre-blank-command": "/home/taras/Documents/info-display/run.sh\n",
+        }
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            if cmd == ["xset", "q"]:
+                return self._completed(XSET_OUTPUT)
+            if cmd[:4] == ["xfconf-query", "-c", "xfce4-power-manager", "-p"] and len(cmd) == 4 + 1:
+                return self._completed(xfce_values[cmd[4]])
+            return self._completed("")
+
+        def fake_save(_logger, settings):
+            saved_settings.clear()
+            saved_settings.update(settings)
+            return True
+
+        with patch.object(mode_switch, "_load_settings", return_value={}), \
+             patch.object(mode_switch, "_save_settings", side_effect=fake_save), \
+             patch.object(mode_switch.subprocess, "run", side_effect=fake_run):
+            mode_switch._disable_dpms_for_eink(self.logger)
+
+        self.assertIn("display_power_saved_state", saved_settings)
+        self.assertEqual(saved_settings["display_power_saved_state"]["xset"]["screensaver_timeout"], 300)
+        self.assertEqual(
+            saved_settings["display_power_saved_state"]["xfce_power_manager"]["/xfce4-power-manager/blank-on-ac"],
+            {"type": "int", "value": 10},
+        )
+        self.assertIn(["xset", "s", "off"], commands)
+        self.assertIn(["xset", "-dpms"], commands)
+        self.assertIn([
+            "xfconf-query", "-c", "xfce4-power-manager", "-p",
+            "/xfce4-power-manager/dpms-enabled", "-s", "false",
+        ], commands)
+        self.assertIn([
+            "xfconf-query", "-c", "xfce4-power-manager", "-p",
+            "/xfce4-power-manager/blank-on-ac", "-s", "0",
+        ], commands)
+        self.assertIn([
+            "xfconf-query", "-c", "xfce4-power-manager", "-p",
+            "/xfce4-power-manager/blank-on-battery", "-s", "0",
+        ], commands)
+
+    def test_disable_for_eink_does_not_overwrite_existing_oled_snapshot(self):
+        existing_snapshot = {
+            "xset": {"screensaver_timeout": 111},
+            "xfce_power_manager": {},
+        }
+        saved = []
+
+        with patch.object(mode_switch, "_load_settings", return_value={"display_power_saved_state": existing_snapshot}), \
+             patch.object(mode_switch, "_save_settings", side_effect=lambda logger, settings: saved.append(settings) or True), \
+             patch.object(mode_switch.subprocess, "run", return_value=self._completed("")):
+            mode_switch._disable_dpms_for_eink(self.logger)
+
+        self.assertEqual(saved, [])
+
+    def test_restore_after_eink_restores_xset_and_xfce_then_clears_snapshot(self):
+        snapshot = {
+            "xset": {
+                "screensaver_timeout": 300,
+                "screensaver_cycle": 300,
+                "dpms_enabled": True,
+                "dpms_standby": 120,
+                "dpms_suspend": 0,
+                "dpms_off": 600,
+            },
+            "xfce_power_manager": {
+                "/xfce4-power-manager/dpms-enabled": {"type": "bool", "value": True},
+                "/xfce4-power-manager/blank-on-ac": {"type": "int", "value": 10},
+                "/xfce4-power-manager/pre-blank-command": {
+                    "type": "string",
+                    "value": "/home/taras/Documents/info-display/run.sh",
+                },
+            },
+        }
+        settings = {"display_power_saved_state": snapshot, "orientation_preference": "left"}
+        saved_settings = []
+        commands = []
+
+        def fake_save(_logger, new_settings):
+            saved_settings.append(dict(new_settings))
+            return True
+
+        with patch.object(mode_switch, "_load_settings", return_value=settings), \
+             patch.object(mode_switch, "_save_settings", side_effect=fake_save), \
+             patch.object(mode_switch.subprocess, "run", side_effect=lambda cmd, **kwargs: commands.append(cmd) or self._completed("")):
+            mode_switch._restore_dpms_after_eink(self.logger)
+
+        self.assertIn(["xset", "s", "300", "300"], commands)
+        self.assertIn(["xset", "+dpms"], commands)
+        self.assertIn(["xset", "dpms", "120", "0", "600"], commands)
+        self.assertIn([
+            "xfconf-query", "-c", "xfce4-power-manager", "-p",
+            "/xfce4-power-manager/dpms-enabled", "-s", "true",
+        ], commands)
+        self.assertIn([
+            "xfconf-query", "-c", "xfce4-power-manager", "-p",
+            "/xfce4-power-manager/blank-on-ac", "-s", "10",
+        ], commands)
+        self.assertEqual(saved_settings[-1], {"orientation_preference": "left"})
+
+    def test_restore_accepts_legacy_dpms_snapshot(self):
+        legacy = {"enabled": False, "standby": 12, "suspend": 0, "off": 34}
+        settings = {"dpms_saved_state": legacy}
+        commands = []
+        saved_settings = []
+
+        with patch.object(mode_switch, "_load_settings", return_value=settings), \
+             patch.object(mode_switch, "_save_settings", side_effect=lambda logger, new_settings: saved_settings.append(dict(new_settings)) or True), \
+             patch.object(mode_switch.subprocess, "run", side_effect=lambda cmd, **kwargs: commands.append(cmd) or self._completed("")):
+            mode_switch._restore_dpms_after_eink(self.logger)
+
+        self.assertIn(["xset", "-dpms"], commands)
+        self.assertEqual(saved_settings[-1], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -84,7 +84,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
              patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
              patch.object(mode_switch, "load_orientation_preference", return_value="normal"), \
              patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode, \
-             patch.object(mode_switch, "ensure_touch_available", return_value=True), \
+             patch.object(mode_switch, "reconcile_touch", return_value=True), \
              patch.object(mode_switch.time, "sleep", return_value=None):
             self.display_mgr.get_active_display.return_value = mode_switch.DISPLAY_OLED
             self.display_mgr.set_display_rotation.return_value = False
@@ -106,7 +106,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
              patch.object(mode_switch, "helper_command", return_value=True), \
              patch.object(mode_switch, "_apply_input_mode", return_value=True), \
              patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
-             patch.object(mode_switch, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(mode_switch, "reconcile_touch", return_value=True) as reconcile_touch, \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_eink(
                 self.display_mgr,
@@ -117,7 +117,12 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             )
 
         self.assertTrue(ok)
-        ensure_touch.assert_called_once_with(self.logger, "eink")
+        reconcile_touch.assert_called_once_with(
+            self.logger,
+            self.display_mgr,
+            target="eink",
+            reason="switch_to_eink",
+        )
 
     def test_switch_to_oled_runs_touch_recovery_after_switch(self):
         with patch.object(mode_switch, "_restore_dpms_after_eink"), \
@@ -126,7 +131,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
              patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
              patch.object(mode_switch, "_apply_input_mode", return_value=True), \
              patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
-             patch.object(mode_switch, "ensure_touch_available", return_value=False) as ensure_touch, \
+             patch.object(mode_switch, "reconcile_touch", return_value=False) as reconcile_touch, \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_oled(
                 self.display_mgr,
@@ -136,7 +141,12 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             )
 
         self.assertTrue(ok)
-        ensure_touch.assert_called_once_with(self.logger, "oled")
+        reconcile_touch.assert_called_once_with(
+            self.logger,
+            self.display_mgr,
+            target="oled",
+            reason="switch_to_oled",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -84,6 +84,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
              patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
              patch.object(mode_switch, "load_orientation_preference", return_value="normal"), \
              patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode, \
+             patch.object(mode_switch, "ensure_touch_available", return_value=True), \
              patch.object(mode_switch.time, "sleep", return_value=None):
             self.display_mgr.get_active_display.return_value = mode_switch.DISPLAY_OLED
             self.display_mgr.set_display_rotation.return_value = False
@@ -98,6 +99,44 @@ class SwitchFlowOrientationTests(unittest.TestCase):
         self.assertTrue(ok)
         self.display_mgr.set_display_rotation.assert_called_once_with(mode_switch.DISPLAY_OLED, "normal")
         apply_input_mode.assert_called_once_with(self.logger, "oled")
+
+    def test_switch_to_eink_runs_touch_recovery_after_switch(self):
+        with patch.object(mode_switch, "_disable_dpms_for_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
+             patch.object(mode_switch, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_eink(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+                enable_frontlight=False,
+            )
+
+        self.assertTrue(ok)
+        ensure_touch.assert_called_once_with(self.logger, "eink")
+
+    def test_switch_to_oled_runs_touch_recovery_after_switch(self):
+        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
+             patch.object(mode_switch, "ensure_touch_available", return_value=False) as ensure_touch, \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_oled(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+            )
+
+        self.assertTrue(ok)
+        ensure_touch.assert_called_once_with(self.logger, "oled")
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import mode_switch
+
+
+class OrientationPreferenceHelpersTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+
+    def test_save_and_load_orientation_preference_round_trip(self):
+        with patch.object(mode_switch, "_load_settings", return_value={}), \
+             patch.object(mode_switch, "_save_settings", return_value=True) as save_settings:
+            saved = mode_switch.save_orientation_preference(self.logger, "left")
+
+        self.assertTrue(saved)
+        save_settings.assert_called_once_with(self.logger, {"orientation_preference": "left"})
+
+        with patch.object(mode_switch, "_load_settings", return_value={"orientation_preference": "normal"}):
+            loaded = mode_switch.load_orientation_preference(self.logger)
+
+        self.assertEqual(loaded, "normal")
+
+    def test_load_orientation_preference_ignores_missing_or_unsupported_values(self):
+        with patch.object(mode_switch, "_load_settings", return_value={}):
+            self.assertIsNone(mode_switch.load_orientation_preference(self.logger))
+
+        with patch.object(mode_switch, "_load_settings", return_value={"orientation_preference": "right"}):
+            self.assertIsNone(mode_switch.load_orientation_preference(self.logger))
+
+
+class ApplyStoredOrientationTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.display_mgr = MagicMock()
+
+    def test_apply_stored_orientation_does_nothing_when_preference_missing(self):
+        with patch.object(mode_switch, "load_orientation_preference", return_value=None):
+            applied = mode_switch.apply_stored_orientation(self.display_mgr, self.logger, target="eink")
+
+        self.assertFalse(applied)
+        self.display_mgr.get_active_display.assert_not_called()
+        self.display_mgr.set_display_rotation.assert_not_called()
+
+
+class SwitchFlowOrientationTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.display_mgr = MagicMock()
+        self.helper = MagicMock()
+
+        self.display_mgr.enable_display.return_value = True
+        self.display_mgr.disable_display.return_value = True
+
+    def test_switch_to_eink_applies_stored_rotation_and_reapplies_input_mode(self):
+        with patch.object(mode_switch, "_disable_dpms_for_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "load_orientation_preference", return_value="left"), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode, \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            self.display_mgr.get_active_display.return_value = mode_switch.DISPLAY_EINK
+            self.display_mgr.set_display_rotation.return_value = True
+
+            ok = mode_switch.switch_to_eink(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+                enable_frontlight=False,
+            )
+
+        self.assertTrue(ok)
+        self.display_mgr.set_display_rotation.assert_called_once_with(mode_switch.DISPLAY_EINK, "left")
+        apply_input_mode.assert_has_calls([
+            call(self.logger, "eink"),
+            call(self.logger, "eink"),
+        ])
+
+    def test_switch_to_oled_stays_successful_when_orientation_apply_fails(self):
+        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch, "load_orientation_preference", return_value="normal"), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode, \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            self.display_mgr.get_active_display.return_value = mode_switch.DISPLAY_OLED
+            self.display_mgr.set_display_rotation.return_value = False
+
+            ok = mode_switch.switch_to_oled(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+            )
+
+        self.assertTrue(ok)
+        self.display_mgr.set_display_rotation.assert_called_once_with(mode_switch.DISPLAY_OLED, "normal")
+        apply_input_mode.assert_called_once_with(self.logger, "oled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -210,6 +210,46 @@ class SwitchFlowOrientationTests(unittest.TestCase):
         finalize_index = calls.index(call.finalize_single_display(mode_switch.DISPLAY_OLED, scale=1.75))
         self.assertGreater(finalize_index, disable_index)
 
+    def test_switch_to_oled_attempts_finalize_reconcile_when_disabling_eink_fails(self):
+        self.display_mgr.disable_display.return_value = False
+
+        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_oled(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+            )
+
+        self.assertFalse(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
+        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+
+    def test_switch_to_eink_attempts_finalize_reconcile_when_disabling_oled_fails(self):
+        self.display_mgr.disable_display.return_value = False
+
+        with patch.object(mode_switch, "_disable_dpms_for_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_eink(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+                enable_frontlight=False,
+            )
+
+        self.assertFalse(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_OLED)
+        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -71,6 +71,8 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             )
 
         self.assertTrue(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_OLED)
         self.display_mgr.set_display_rotation.assert_called_once_with(mode_switch.DISPLAY_EINK, "left")
         apply_input_mode.assert_has_calls([
             call(self.logger, "eink"),
@@ -97,6 +99,8 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             )
 
         self.assertTrue(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
         self.display_mgr.set_display_rotation.assert_called_once_with(mode_switch.DISPLAY_OLED, "normal")
         apply_input_mode.assert_called_once_with(self.logger, "oled")
 
@@ -107,6 +111,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
              patch.object(mode_switch, "_apply_input_mode", return_value=True), \
              patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
              patch.object(mode_switch, "reconcile_touch", return_value=True) as reconcile_touch, \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot") as log_snapshot, \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_eink(
                 self.display_mgr,
@@ -123,6 +128,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             target="eink",
             reason="switch_to_eink",
         )
+        log_snapshot.assert_called_once_with(self.logger, "switch_to_eink")
 
     def test_switch_to_oled_runs_touch_recovery_after_switch(self):
         with patch.object(mode_switch, "_restore_dpms_after_eink"), \
@@ -132,6 +138,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
              patch.object(mode_switch, "_apply_input_mode", return_value=True), \
              patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
              patch.object(mode_switch, "reconcile_touch", return_value=False) as reconcile_touch, \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot") as log_snapshot, \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_oled(
                 self.display_mgr,
@@ -147,6 +154,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             target="oled",
             reason="switch_to_oled",
         )
+        log_snapshot.assert_called_once_with(self.logger, "switch_to_oled")
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -210,13 +210,18 @@ class SwitchFlowOrientationTests(unittest.TestCase):
         finalize_index = calls.index(call.finalize_single_display(mode_switch.DISPLAY_OLED, scale=1.75))
         self.assertGreater(finalize_index, disable_index)
 
-    def test_switch_to_oled_attempts_finalize_reconcile_when_disabling_eink_fails(self):
+    def test_switch_to_oled_converges_when_disabling_eink_fails_but_finalize_succeeds(self):
         self.display_mgr.disable_display.return_value = False
+        self.display_mgr.finalize_single_display.return_value = True
 
         with patch.object(mode_switch, "_restore_dpms_after_eink"), \
              patch.object(mode_switch, "set_xfce_theme", return_value=True), \
              patch.object(mode_switch, "helper_command", return_value=True), \
              patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
+             patch.object(mode_switch, "reconcile_touch", return_value=True), \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot"), \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_oled(
                 self.display_mgr,
@@ -225,17 +230,22 @@ class SwitchFlowOrientationTests(unittest.TestCase):
                 autoswitch_theme=False,
             )
 
-        self.assertFalse(ok)
+        self.assertTrue(ok)
         self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
         self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
         self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
 
-    def test_switch_to_eink_attempts_finalize_reconcile_when_disabling_oled_fails(self):
+    def test_switch_to_eink_converges_when_disabling_oled_fails_but_finalize_succeeds(self):
         self.display_mgr.disable_display.return_value = False
+        self.display_mgr.finalize_single_display.return_value = True
 
         with patch.object(mode_switch, "_disable_dpms_for_eink"), \
              patch.object(mode_switch, "set_xfce_theme", return_value=True), \
              patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
+             patch.object(mode_switch, "reconcile_touch", return_value=True), \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot"), \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_eink(
                 self.display_mgr,
@@ -245,7 +255,7 @@ class SwitchFlowOrientationTests(unittest.TestCase):
                 enable_frontlight=False,
             )
 
-        self.assertFalse(ok)
+        self.assertTrue(ok)
         self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
         self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_OLED)
         self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -235,6 +235,24 @@ class SwitchFlowOrientationTests(unittest.TestCase):
         self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
         self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
 
+    def test_switch_to_oled_sets_dark_theme_before_finalize_failure(self):
+        self.display_mgr.finalize_single_display.return_value = False
+
+        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True) as set_theme, \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_oled(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=True,
+            )
+
+        self.assertFalse(ok)
+        set_theme.assert_called_once_with(self.logger, mode_switch.THEME_ADWAITA_DARK)
+
     def test_switch_to_eink_converges_when_disabling_oled_fails_but_finalize_succeeds(self):
         self.display_mgr.disable_display.return_value = False
         self.display_mgr.finalize_single_display.return_value = True

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -130,6 +130,33 @@ class SwitchFlowOrientationTests(unittest.TestCase):
         )
         log_snapshot.assert_called_once_with(self.logger, "switch_to_eink")
 
+    def test_switch_to_eink_finalizes_single_output_after_disabling_oled(self):
+        with patch.object(mode_switch, "_disable_dpms_for_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
+             patch.object(mode_switch, "reconcile_touch", return_value=True), \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot"), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_eink(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+                enable_frontlight=False,
+            )
+
+        self.assertTrue(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_OLED)
+        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+
+        calls = self.display_mgr.mock_calls
+        disable_index = calls.index(call.disable_display(mode_switch.DISPLAY_OLED))
+        finalize_index = calls.index(call.finalize_single_display(mode_switch.DISPLAY_EINK, scale=1.75))
+        self.assertGreater(finalize_index, disable_index)
+
     def test_switch_to_oled_runs_touch_recovery_after_switch(self):
         with patch.object(mode_switch, "_restore_dpms_after_eink"), \
              patch.object(mode_switch, "set_xfce_theme", return_value=True), \
@@ -155,6 +182,33 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             reason="switch_to_oled",
         )
         log_snapshot.assert_called_once_with(self.logger, "switch_to_oled")
+
+    def test_switch_to_oled_finalizes_single_output_after_disabling_eink(self):
+        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
+             patch.object(mode_switch, "reconcile_touch", return_value=False), \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot"), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_oled(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=False,
+            )
+
+        self.assertTrue(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
+        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+
+        calls = self.display_mgr.mock_calls
+        disable_index = calls.index(call.disable_display(mode_switch.DISPLAY_EINK))
+        finalize_index = calls.index(call.finalize_single_display(mode_switch.DISPLAY_OLED, scale=1.75))
+        self.assertGreater(finalize_index, disable_index)
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_rotation.py
+++ b/tests/test_mode_switch_rotation.py
@@ -43,6 +43,54 @@ class ApplyStoredOrientationTests(unittest.TestCase):
         self.display_mgr.set_display_rotation.assert_not_called()
 
 
+class SingleDisplayConvergenceTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.display_mgr = MagicMock()
+        self.display_mgr.enable_display.return_value = True
+        self.display_mgr.disable_display.return_value = True
+        self.display_mgr.finalize_single_display.return_value = True
+
+    def test_converge_single_display_runs_critical_steps_in_order(self):
+        target = mode_switch._build_switch_target("oled")
+
+        ok = mode_switch._converge_single_display(self.display_mgr, self.logger, target, scale=1.75)
+
+        self.assertTrue(ok)
+        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
+        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
+        calls = self.display_mgr.mock_calls
+        self.assertLess(
+            calls.index(call.enable_display(mode_switch.DISPLAY_OLED, scale=1.75)),
+            calls.index(call.disable_display(mode_switch.DISPLAY_EINK)),
+        )
+        self.assertLess(
+            calls.index(call.disable_display(mode_switch.DISPLAY_EINK)),
+            calls.index(call.finalize_single_display(mode_switch.DISPLAY_OLED, scale=1.75)),
+        )
+
+    def test_converge_single_display_fails_fast_when_critical_step_fails(self):
+        target = mode_switch._build_switch_target("eink")
+        self.display_mgr.disable_display.return_value = False
+
+        ok = mode_switch._converge_single_display(self.display_mgr, self.logger, target, scale=1.75)
+
+        self.assertFalse(ok)
+        self.display_mgr.finalize_single_display.assert_not_called()
+
+    def test_converge_single_display_logs_mode_outputs_and_failed_step(self):
+        target = mode_switch._build_switch_target("oled")
+        self.display_mgr.finalize_single_display.return_value = False
+
+        ok = mode_switch._converge_single_display(self.display_mgr, self.logger, target, scale=1.75)
+
+        self.assertFalse(ok)
+        self.logger.error.assert_any_call(
+            "Display convergence failed for mode=oled step=finalize target_output=eDP-1 other_output=eDP-2"
+        )
+
+
 class SwitchFlowOrientationTests(unittest.TestCase):
     def setUp(self):
         self.logger = MagicMock()
@@ -210,38 +258,17 @@ class SwitchFlowOrientationTests(unittest.TestCase):
         finalize_index = calls.index(call.finalize_single_display(mode_switch.DISPLAY_OLED, scale=1.75))
         self.assertGreater(finalize_index, disable_index)
 
-    def test_switch_to_oled_converges_when_disabling_eink_fails_but_finalize_succeeds(self):
+    def test_switch_to_oled_fails_fast_when_disabling_eink_fails(self):
         self.display_mgr.disable_display.return_value = False
-        self.display_mgr.finalize_single_display.return_value = True
 
-        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
-             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
-             patch.object(mode_switch, "helper_command", return_value=True), \
-             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
-             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
-             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
-             patch.object(mode_switch, "reconcile_touch", return_value=True), \
-             patch.object(mode_switch, "_log_post_switch_display_snapshot"), \
-             patch.object(mode_switch.time, "sleep", return_value=None):
-            ok = mode_switch.switch_to_oled(
-                self.display_mgr,
-                self.helper,
-                self.logger,
-                autoswitch_theme=False,
-            )
-
-        self.assertTrue(ok)
-        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
-        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_EINK)
-        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_OLED, scale=1.75)
-
-    def test_switch_to_oled_sets_dark_theme_before_finalize_failure(self):
-        self.display_mgr.finalize_single_display.return_value = False
-
-        with patch.object(mode_switch, "_restore_dpms_after_eink"), \
+        with patch.object(mode_switch, "_restore_dpms_after_eink") as restore_dpms, \
              patch.object(mode_switch, "set_xfce_theme", return_value=True) as set_theme, \
              patch.object(mode_switch, "helper_command", return_value=True), \
              patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode, \
+             patch.object(mode_switch, "apply_stored_orientation") as apply_orientation, \
+             patch.object(mode_switch, "reconcile_touch") as reconcile_touch, \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot") as log_snapshot, \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_oled(
                 self.display_mgr,
@@ -251,32 +278,125 @@ class SwitchFlowOrientationTests(unittest.TestCase):
             )
 
         self.assertFalse(ok)
-        set_theme.assert_called_once_with(self.logger, mode_switch.THEME_ADWAITA_DARK)
+        self.display_mgr.finalize_single_display.assert_not_called()
+        set_theme.assert_not_called()
+        restore_dpms.assert_not_called()
+        apply_input_mode.assert_not_called()
+        apply_orientation.assert_not_called()
+        reconcile_touch.assert_not_called()
+        log_snapshot.assert_not_called()
 
-    def test_switch_to_eink_converges_when_disabling_oled_fails_but_finalize_succeeds(self):
+    def test_switch_to_oled_cleans_up_privacy_image_when_convergence_fails(self):
+        image_process = MagicMock()
+
+        with patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_converge_single_display", return_value=False), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value="privacy.jpg"), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            self.display_mgr.display_fullscreen_image.return_value = image_process
+
+            ok = mode_switch.switch_to_oled(
+                self.display_mgr,
+                self.helper,
+                self.logger,
+                autoswitch_theme=True,
+            )
+
+        self.assertFalse(ok)
+        image_process.terminate.assert_called_once()
+        image_process.wait.assert_called_once_with(timeout=2)
+
+    def test_switch_to_eink_fails_fast_when_disabling_oled_fails(self):
         self.display_mgr.disable_display.return_value = False
-        self.display_mgr.finalize_single_display.return_value = True
 
-        with patch.object(mode_switch, "_disable_dpms_for_eink"), \
-             patch.object(mode_switch, "set_xfce_theme", return_value=True), \
+        with patch.object(mode_switch, "_disable_dpms_for_eink") as disable_dpms, \
+             patch.object(mode_switch, "set_xfce_theme", return_value=True) as set_theme, \
              patch.object(mode_switch, "helper_command", return_value=True), \
-             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
-             patch.object(mode_switch, "apply_stored_orientation", return_value=False), \
-             patch.object(mode_switch, "reconcile_touch", return_value=True), \
-             patch.object(mode_switch, "_log_post_switch_display_snapshot"), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True) as apply_input_mode, \
+             patch.object(mode_switch, "apply_stored_orientation") as apply_orientation, \
+             patch.object(mode_switch, "reconcile_touch") as reconcile_touch, \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot") as log_snapshot, \
              patch.object(mode_switch.time, "sleep", return_value=None):
             ok = mode_switch.switch_to_eink(
                 self.display_mgr,
                 self.helper,
                 self.logger,
-                autoswitch_theme=False,
+                autoswitch_theme=True,
+                enable_frontlight=False,
+            )
+
+        self.assertFalse(ok)
+        self.display_mgr.finalize_single_display.assert_not_called()
+        disable_dpms.assert_not_called()
+        set_theme.assert_not_called()
+        apply_input_mode.assert_not_called()
+        apply_orientation.assert_not_called()
+        reconcile_touch.assert_not_called()
+        log_snapshot.assert_not_called()
+
+    def test_switch_to_oled_defers_follow_up_work_until_after_display_convergence(self):
+        events = []
+
+        self.display_mgr.enable_display.side_effect = lambda *args, **kwargs: events.append("enable") or True
+        self.display_mgr.disable_display.side_effect = lambda *args, **kwargs: events.append("disable") or True
+        self.display_mgr.finalize_single_display.side_effect = lambda *args, **kwargs: events.append("finalize") or True
+
+        with patch.object(mode_switch, "helper_command", side_effect=lambda *args, **kwargs: events.append(f"helper:{args[2]}") or True), \
+             patch.object(mode_switch, "set_xfce_theme", side_effect=lambda *args, **kwargs: events.append("theme") or True), \
+             patch.object(mode_switch, "_restore_dpms_after_eink", side_effect=lambda *args, **kwargs: events.append("restore-dpms")), \
+             patch.object(mode_switch, "_apply_input_mode", side_effect=lambda *args, **kwargs: events.append("input") or True), \
+             patch.object(mode_switch, "apply_stored_orientation", side_effect=lambda *args, **kwargs: events.append("orientation") or False), \
+             patch.object(mode_switch, "reconcile_touch", side_effect=lambda *args, **kwargs: events.append("touch") or True), \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot", side_effect=lambda *args, **kwargs: events.append("snapshot")), \
+             patch.object(mode_switch, "_resolve_privacy_image_path", return_value=None), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_oled(self.display_mgr, self.helper, self.logger)
+
+        self.assertTrue(ok)
+        self.assertLess(events.index("enable"), events.index("disable"))
+        self.assertLess(events.index("disable"), events.index("finalize"))
+        self.assertLess(events.index("finalize"), events.index("theme"))
+        self.assertLess(events.index("finalize"), events.index("restore-dpms"))
+        self.assertLess(events.index("finalize"), events.index("input"))
+        self.assertLess(events.index("finalize"), events.index("orientation"))
+        self.assertLess(events.index("finalize"), events.index("touch"))
+        self.assertLess(events.index("finalize"), events.index("snapshot"))
+
+    def test_switch_to_eink_defers_follow_up_work_until_after_display_convergence(self):
+        events = []
+
+        self.display_mgr.enable_display.side_effect = lambda *args, **kwargs: events.append("enable") or True
+        self.display_mgr.disable_display.side_effect = lambda *args, **kwargs: events.append("disable") or True
+        self.display_mgr.finalize_single_display.side_effect = lambda *args, **kwargs: events.append("finalize") or True
+
+        def helper_side_effect(*args, **kwargs):
+            events.append(f"helper:{args[2]}")
+            return True
+
+        with patch.object(mode_switch, "helper_command", side_effect=helper_side_effect), \
+             patch.object(mode_switch, "_disable_dpms_for_eink", side_effect=lambda *args, **kwargs: events.append("disable-dpms")), \
+             patch.object(mode_switch, "set_xfce_theme", side_effect=lambda *args, **kwargs: events.append("theme") or True), \
+             patch.object(mode_switch, "_apply_input_mode", side_effect=lambda *args, **kwargs: events.append("input") or True), \
+             patch.object(mode_switch, "apply_stored_orientation", side_effect=lambda *args, **kwargs: events.append("orientation") or False), \
+             patch.object(mode_switch, "reconcile_touch", side_effect=lambda *args, **kwargs: events.append("touch") or True), \
+             patch.object(mode_switch, "_log_post_switch_display_snapshot", side_effect=lambda *args, **kwargs: events.append("snapshot")), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            ok = mode_switch.switch_to_eink(
+                self.display_mgr,
+                self.helper,
+                self.logger,
                 enable_frontlight=False,
             )
 
         self.assertTrue(ok)
-        self.display_mgr.enable_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
-        self.display_mgr.disable_display.assert_called_once_with(mode_switch.DISPLAY_OLED)
-        self.display_mgr.finalize_single_display.assert_called_once_with(mode_switch.DISPLAY_EINK, scale=1.75)
+        self.assertLess(events.index("enable"), events.index("disable"))
+        self.assertLess(events.index("disable"), events.index("finalize"))
+        self.assertLess(events.index("finalize"), events.index("disable-dpms"))
+        self.assertLess(events.index("finalize"), events.index("theme"))
+        self.assertLess(events.index("finalize"), events.index("input"))
+        self.assertLess(events.index("finalize"), events.index("orientation"))
+        self.assertLess(events.index("finalize"), events.index("touch"))
+        self.assertLess(events.index("finalize"), events.index("snapshot"))
 
 
 if __name__ == "__main__":

--- a/tests/test_mode_switch_state.py
+++ b/tests/test_mode_switch_state.py
@@ -128,6 +128,61 @@ class ToggleEinkCliStateTests(unittest.TestCase):
         switch_to_oled.assert_not_called()
         switch_to_eink.assert_called_once()
 
+    def test_cli_switch_path_applies_stored_orientation_via_shared_mode_switch(self):
+        toggle_eink = load_toggle_eink_module()
+
+        logger = MagicMock()
+
+        class FakeDisplayManager:
+            last_instance = None
+
+            def __init__(self, _logger):
+                self.__class__.last_instance = self
+                self.rotation_calls = []
+
+            def is_display_active(self, display_name):
+                return display_name == mode_switch.DISPLAY_OLED
+
+            def enable_display(self, _display_name, scale=None):
+                return True
+
+            def disable_display(self, _display_name):
+                return True
+
+            def get_active_display(self):
+                return mode_switch.DISPLAY_EINK
+
+            def set_display_rotation(self, display_name, rotation):
+                self.rotation_calls.append((display_name, rotation))
+                return True
+
+        class FakeHelperClient:
+            def __init__(self, _logger):
+                self.connected = True
+
+            def connect(self, _socket_path, timeout=10.0):
+                return True
+
+            def is_connected(self):
+                return self.connected
+
+            def disconnect(self):
+                self.connected = False
+
+        with patch.object(toggle_eink, "setup_logger", return_value=logger), \
+             patch.object(toggle_eink, "DisplayManager", FakeDisplayManager), \
+             patch.object(toggle_eink, "HelperClient", FakeHelperClient), \
+             patch.object(toggle_eink, "load_settings", return_value={"display_scale": 1.75, "autoswitch_theme": False}), \
+             patch.object(mode_switch, "_disable_dpms_for_eink"), \
+             patch.object(mode_switch, "helper_command", return_value=True), \
+             patch.object(mode_switch, "_apply_input_mode", return_value=True), \
+             patch.object(mode_switch, "load_orientation_preference", return_value="left"), \
+             patch.object(mode_switch.time, "sleep", return_value=None):
+            exit_code = toggle_eink.main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(FakeDisplayManager.last_instance.rotation_calls, [(mode_switch.DISPLAY_EINK, "left")])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mode_switch_state.py
+++ b/tests/test_mode_switch_state.py
@@ -1,0 +1,73 @@
+import unittest
+
+import mode_switch
+
+
+class FakeDisplayManager:
+    def __init__(self, active_map):
+        self.active_map = active_map
+
+    def is_display_active(self, display_name):
+        return self.active_map.get(display_name, False)
+
+
+class GetDisplayStateTests(unittest.TestCase):
+    def test_only_edp2_active_reports_eink_mode(self):
+        display_mgr = FakeDisplayManager({"eDP-1": False, "eDP-2": True})
+
+        state = mode_switch.get_display_state(display_mgr)
+
+        self.assertEqual(
+            state,
+            {
+                "oled_active": False,
+                "eink_active": True,
+                "mode": "eink",
+            },
+        )
+
+    def test_only_edp1_active_reports_oled_mode(self):
+        display_mgr = FakeDisplayManager({"eDP-1": True, "eDP-2": False})
+
+        state = mode_switch.get_display_state(display_mgr)
+
+        self.assertEqual(
+            state,
+            {
+                "oled_active": True,
+                "eink_active": False,
+                "mode": "oled",
+            },
+        )
+
+    def test_both_displays_active_reports_mixed_mode(self):
+        display_mgr = FakeDisplayManager({"eDP-1": True, "eDP-2": True})
+
+        state = mode_switch.get_display_state(display_mgr)
+
+        self.assertEqual(
+            state,
+            {
+                "oled_active": True,
+                "eink_active": True,
+                "mode": "mixed",
+            },
+        )
+
+    def test_neither_display_active_reports_unknown_mode(self):
+        display_mgr = FakeDisplayManager({"eDP-1": False, "eDP-2": False})
+
+        state = mode_switch.get_display_state(display_mgr)
+
+        self.assertEqual(
+            state,
+            {
+                "oled_active": False,
+                "eink_active": False,
+                "mode": "unknown",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mode_switch_state.py
+++ b/tests/test_mode_switch_state.py
@@ -89,6 +89,38 @@ class GetDisplayStateTests(unittest.TestCase):
         )
 
 
+class SwitchTargetMetadataTests(unittest.TestCase):
+    def test_build_switch_target_returns_expected_oled_metadata(self):
+        target = mode_switch._build_switch_target("oled")
+
+        self.assertEqual(
+            target,
+            {
+                "mode": "oled",
+                "target_output": mode_switch.DISPLAY_OLED,
+                "other_output": mode_switch.DISPLAY_EINK,
+                "theme": mode_switch.THEME_ADWAITA_DARK,
+                "input_target": "oled",
+                "snapshot_reason": "switch_to_oled",
+            },
+        )
+
+    def test_build_switch_target_returns_expected_eink_metadata(self):
+        target = mode_switch._build_switch_target("eink")
+
+        self.assertEqual(
+            target,
+            {
+                "mode": "eink",
+                "target_output": mode_switch.DISPLAY_EINK,
+                "other_output": mode_switch.DISPLAY_OLED,
+                "theme": mode_switch.THEME_HIGH_CONTRAST,
+                "input_target": "eink",
+                "snapshot_reason": "switch_to_eink",
+            },
+        )
+
+
 class ToggleEinkCliStateTests(unittest.TestCase):
     def test_cli_uses_shared_state_mode_for_toggle_direction(self):
         toggle_eink = load_toggle_eink_module()

--- a/tests/test_mode_switch_state.py
+++ b/tests/test_mode_switch_state.py
@@ -149,6 +149,9 @@ class ToggleEinkCliStateTests(unittest.TestCase):
             def disable_display(self, _display_name):
                 return True
 
+            def finalize_single_display(self, _display_name, scale=None):
+                return True
+
             def get_active_display(self):
                 return mode_switch.DISPLAY_EINK
 

--- a/tests/test_mode_switch_state.py
+++ b/tests/test_mode_switch_state.py
@@ -1,4 +1,8 @@
+import importlib.util
+import sys
 import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import mode_switch
 
@@ -9,6 +13,22 @@ class FakeDisplayManager:
 
     def is_display_active(self, display_name):
         return self.active_map.get(display_name, False)
+
+
+TOGGLE_EINK_PATH = Path(__file__).resolve().parent.parent / "toggle-eink.py"
+
+
+def load_toggle_eink_module():
+    module_name = "toggle_eink_cli"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, TOGGLE_EINK_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 class GetDisplayStateTests(unittest.TestCase):
@@ -67,6 +87,46 @@ class GetDisplayStateTests(unittest.TestCase):
                 "mode": "unknown",
             },
         )
+
+
+class ToggleEinkCliStateTests(unittest.TestCase):
+    def test_cli_uses_shared_state_mode_for_toggle_direction(self):
+        toggle_eink = load_toggle_eink_module()
+
+        logger = MagicMock()
+
+        class FakeDisplayManager:
+            def __init__(self, _logger):
+                pass
+
+            def is_display_active(self, _display_name):
+                raise AssertionError("CLI must not read raw display activity directly")
+
+        class FakeHelperClient:
+            def __init__(self, _logger):
+                self.connected = True
+
+            def connect(self, _socket_path, timeout=10.0):
+                return True
+
+            def is_connected(self):
+                return self.connected
+
+            def disconnect(self):
+                self.connected = False
+
+        with patch.object(toggle_eink, "setup_logger", return_value=logger), \
+             patch.object(toggle_eink, "DisplayManager", FakeDisplayManager), \
+             patch.object(toggle_eink, "HelperClient", FakeHelperClient), \
+             patch.object(toggle_eink, "load_settings", return_value={"display_scale": 1.75, "autoswitch_theme": True}), \
+             patch.object(toggle_eink, "get_display_state", return_value={"oled_active": True, "eink_active": True, "mode": "mixed"}), \
+             patch.object(toggle_eink, "switch_to_oled", return_value=True) as switch_to_oled, \
+             patch.object(toggle_eink, "switch_to_eink", return_value=True) as switch_to_eink:
+            exit_code = toggle_eink.main()
+
+        self.assertEqual(exit_code, 0)
+        switch_to_oled.assert_not_called()
+        switch_to_eink.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -268,6 +268,21 @@ class OrientationUiTests(unittest.TestCase):
 
         apply_mode.assert_called_once_with(gui.logger, "oled")
 
+    def test_toggle_orientation_runs_touch_recovery_for_current_target(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-1"
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "normal", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True), \
+             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+            Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
+
+        ensure_touch.assert_called_once_with(gui.logger, "oled")
+
     def test_toggle_orientation_updates_ui_after_confirming_live_rotation(self):
         gui = self.make_gui()
         gui.display_mgr.get_active_display.return_value = "eDP-1"
@@ -330,6 +345,198 @@ class FrontlightRecoveryTests(unittest.TestCase):
         self.assertEqual(gui.brightness_scale.cget("state"), "disabled")
         self.assertTrue(gui.secure_boot_warning.grid_called)
         gui.sync_frontlight_state.assert_not_called()
+
+
+class LiveStateReconcilerTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.display_mgr = MagicMock()
+        gui.logger = MagicMock()
+        gui.log_message = MagicMock()
+        gui.update_status = MagicMock()
+        gui.sync_ui_from_display_state = MagicMock()
+        return gui
+
+    def test_reconciler_tracks_display_lid_inhibitor_and_orientation_state(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-2"
+        gui.display_mgr.get_display_rotation.return_value = "left"
+
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
+             patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc):
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        self.assertEqual(gui._live_sync_state["display_mode"], "eink")
+        self.assertTrue(gui._live_sync_state["lid_closed"])
+        self.assertTrue(gui._live_sync_state["inhibitor_running"])
+        self.assertEqual(gui._live_sync_state["last_eink_orientation"], "left")
+
+    def test_reconciler_reads_live_display_and_lid_state(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}) as get_state, \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=False) as get_lid:
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        get_state.assert_called_once_with(gui.display_mgr)
+        get_lid.assert_called_once()
+
+
+class InhibitorLifecycleTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.display_mgr = MagicMock()
+        gui.display_mgr.get_active_display.return_value = None
+        gui.sync_ui_from_display_state = MagicMock()
+        gui.logger = MagicMock()
+        gui.log_message = MagicMock()
+        return gui
+
+    def test_reconciler_starts_lid_inhibitor_when_eink_becomes_active(self):
+        gui = self.make_gui()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=False), \
+             patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc) as popen:
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        popen.assert_called_once()
+        self.assertTrue(gui._live_sync_state["inhibitor_running"])
+
+    def test_reconciler_stops_lid_inhibitor_when_display_leaves_eink(self):
+        gui = self.make_gui()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+        gui._lid_inhibitor_process = fake_proc
+        gui._live_sync_state = {
+            "display_mode": "eink",
+            "lid_closed": False,
+            "inhibitor_running": True,
+            "last_eink_orientation": None,
+        }
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=False):
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        fake_proc.terminate.assert_called_once()
+        self.assertFalse(gui._live_sync_state["inhibitor_running"])
+
+    def test_reconciler_does_not_spawn_duplicate_lid_inhibitors(self):
+        gui = self.make_gui()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=False), \
+             patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc) as popen:
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        popen.assert_called_once()
+
+
+class EventWatcherLifecycleTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.logger = MagicMock()
+        gui.log_message = MagicMock()
+        gui.root = type("Root", (), {"after": MagicMock()})()
+        return gui
+
+    def test_start_and_stop_event_watcher_process(self):
+        gui = self.make_gui()
+        fake_parent = MagicMock()
+        fake_child = MagicMock()
+        fake_process = MagicMock()
+
+        with patch.object(Tinta4Plus, "Pipe", return_value=(fake_parent, fake_child)) as make_pipe, \
+             patch.object(Tinta4Plus, "Process", return_value=fake_process) as make_process:
+            Tinta4Plus.EInkControlGUI._start_event_watcher(gui)
+            Tinta4Plus.EInkControlGUI._stop_event_watcher(gui)
+
+        make_pipe.assert_called_once_with(duplex=False)
+        make_process.assert_called_once()
+        fake_process.start.assert_called_once()
+        fake_parent.close.assert_called_once()
+        fake_child.close.assert_called_once()
+        fake_process.join.assert_called_once()
+
+    def test_event_watcher_uses_single_ipc_channel(self):
+        gui = self.make_gui()
+        fake_parent = MagicMock()
+        fake_child = MagicMock()
+
+        with patch.object(Tinta4Plus, "Pipe", return_value=(fake_parent, fake_child)), \
+             patch.object(Tinta4Plus, "Process", return_value=MagicMock()) as make_process:
+            Tinta4Plus.EInkControlGUI._start_event_watcher(gui)
+
+        kwargs = make_process.call_args.kwargs
+        self.assertEqual(kwargs["args"], (fake_child,))
+
+    def test_event_watcher_helper_notification_shapes(self):
+        import event_watcher
+
+        sent = []
+        event_watcher.send_lid_invalidation(sent.append)
+        event_watcher.send_randr_invalidation(sent.append)
+        event_watcher.send_error(sent.append, "boom")
+
+        self.assertEqual(sent[0], ("lid", None))
+        self.assertEqual(sent[1], ("randr", None))
+        self.assertEqual(sent[2], ("error", "boom"))
+
+
+class EventWatcherNotificationTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.logger = MagicMock()
+        gui.log_message = MagicMock()
+        gui._reconcile_from_live_state = MagicMock()
+        gui.root = type("Root", (), {"after": MagicMock(side_effect=lambda _delay, callback: callback())})()
+        return gui
+
+    def test_lid_and_randr_notifications_schedule_tk_thread_reconcile(self):
+        gui = self.make_gui()
+        conn = MagicMock()
+        conn.poll.side_effect = [True, True, False]
+        conn.recv.side_effect = [("lid", None), ("randr", None)]
+        gui._event_watcher_conn = conn
+
+        Tinta4Plus.EInkControlGUI._drain_event_watcher_notifications(gui)
+
+        self.assertEqual(gui._reconcile_from_live_state.call_count, 2)
+
+    def test_notification_drain_does_not_do_direct_side_effects(self):
+        gui = self.make_gui()
+        gui.sync_ui_from_display_state = MagicMock()
+        conn = MagicMock()
+        conn.poll.side_effect = [True, False]
+        conn.recv.return_value = ("lid", None)
+        gui._event_watcher_conn = conn
+
+        Tinta4Plus.EInkControlGUI._drain_event_watcher_notifications(gui)
+
+        gui.sync_ui_from_display_state.assert_not_called()
+
+    def test_error_notification_is_logged_without_crash(self):
+        gui = self.make_gui()
+        conn = MagicMock()
+        conn.poll.side_effect = [True, False]
+        conn.recv.return_value = ("error", "watcher failed")
+        gui._event_watcher_conn = conn
+
+        Tinta4Plus.EInkControlGUI._drain_event_watcher_notifications(gui)
+
+        gui.log_message.assert_called_once()
+        gui._reconcile_from_live_state.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -91,5 +91,93 @@ class UiStateSyncTests(unittest.TestCase):
         gui.log_message.assert_called()
 
 
+class GuiLifecycleSyncTests(unittest.TestCase):
+    def test_initialize_helper_syncs_ui_after_successful_connect(self):
+        gui = type("GuiStub", (), {})()
+        gui._prompt_install_or_upgrade = MagicMock(return_value=True)
+        gui.helper = MagicMock()
+        gui.helper.connect.return_value = True
+        gui.SOCKET_PATH = "/run/tinta4plus.sock"
+        gui.SOCKET_TIMEOUT = 10.0
+        gui.update_status = MagicMock()
+        gui.log_message = MagicMock()
+        gui.root = type("Root", (), {"after": MagicMock()})()
+        gui.check_ec_status = MagicMock()
+        gui.sync_ui_from_display_state = MagicMock()
+
+        Tinta4Plus.EInkControlGUI.initialize_helper(gui)
+
+        gui.sync_ui_from_display_state.assert_called_once()
+
+    def test_attempt_helper_restart_syncs_ui_after_successful_reconnect(self):
+        gui = type("GuiStub", (), {})()
+        gui.log_message = MagicMock()
+        gui.helper = MagicMock()
+        gui.helper.is_connected.return_value = True
+        gui.helper.connect.return_value = True
+        gui.logger = MagicMock()
+        gui.SOCKET_PATH = "/run/tinta4plus.sock"
+        gui.SOCKET_TIMEOUT = 10.0
+        gui.update_status = MagicMock()
+        gui.root = type("Root", (), {"after": MagicMock()})()
+        gui.check_ec_status = MagicMock()
+        gui.sync_ui_from_display_state = MagicMock()
+
+        with patch.object(Tinta4Plus.time, "sleep", return_value=None):
+            Tinta4Plus.EInkControlGUI.attempt_helper_restart(gui)
+
+        gui.sync_ui_from_display_state.assert_called_once()
+
+    def test_toggle_to_eink_uses_sync_ui_on_success(self):
+        gui = type("GuiStub", (), {})()
+        gui.eink_enabled_var = FakeVar(False)
+        gui.display_mgr = object()
+        gui.helper = object()
+        gui.logger = MagicMock()
+        gui.display_scale = 1.75
+        gui.autoswitch_theme_var = FakeVar(True)
+        gui.brightness_var = FakeVar(4)
+        gui.sync_ui_from_display_state = MagicMock()
+        gui.log_message = MagicMock()
+        gui.root = object()
+        gui.on_refresh_full = MagicMock()
+        gui.btn_refresh = FakeWidget()
+        gui.btn_set_dynamic = FakeWidget()
+        gui.btn_set_reading = FakeWidget()
+        gui.eink_toggle_btn = FakeWidget()
+        gui._start_refresh_timer = MagicMock()
+        gui.floating_refresh_button = None
+        gui.update_status = MagicMock()
+
+        with patch.object(Tinta4Plus, "switch_to_eink", return_value=True), \
+             patch.object(Tinta4Plus, "FloatingRefreshButton", MagicMock()):
+            Tinta4Plus.EInkControlGUI.on_eink_toggled(gui)
+
+        gui.sync_ui_from_display_state.assert_called_once()
+
+    def test_toggle_to_oled_uses_sync_ui_on_success(self):
+        gui = type("GuiStub", (), {})()
+        gui.eink_enabled_var = FakeVar(True)
+        gui.display_mgr = object()
+        gui.helper = object()
+        gui.logger = MagicMock()
+        gui.display_scale = 1.75
+        gui.autoswitch_theme_var = FakeVar(True)
+        gui.sync_ui_from_display_state = MagicMock()
+        gui.log_message = MagicMock()
+        gui._stop_refresh_timer = MagicMock()
+        gui.floating_refresh_button = None
+        gui.btn_refresh = FakeWidget()
+        gui.btn_set_dynamic = FakeWidget()
+        gui.btn_set_reading = FakeWidget()
+        gui.eink_toggle_btn = FakeWidget()
+        gui.update_status = MagicMock()
+
+        with patch.object(Tinta4Plus, "switch_to_oled", return_value=True):
+            Tinta4Plus.EInkControlGUI.on_eink_toggled(gui)
+
+        gui.sync_ui_from_display_state.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -191,6 +191,24 @@ class GuiLifecycleSyncTests(unittest.TestCase):
 
         gui.sync_ui_from_display_state.assert_called_once()
 
+    def test_on_closing_does_not_toggle_display_mode(self):
+        gui = type("GuiStub", (), {})()
+        gui.logger = MagicMock()
+        gui.eink_enabled_var = FakeVar(True)
+        gui.log_message = MagicMock()
+        gui.on_eink_toggled = MagicMock()
+        gui._stop_refresh_timer = MagicMock()
+        gui.helper = MagicMock()
+        gui.helper.is_connected.return_value = True
+        gui.root = MagicMock()
+
+        Tinta4Plus.EInkControlGUI.on_closing(gui)
+
+        gui.on_eink_toggled.assert_not_called()
+        gui._stop_refresh_timer.assert_called_once()
+        gui.helper.disconnect.assert_called_once()
+        gui.root.destroy.assert_called_once()
+
 
 class FrontlightRecoveryTests(unittest.TestCase):
     def make_gui(self, ec_status):

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -105,7 +105,7 @@ class UiStateSyncTests(unittest.TestCase):
 
 
 class GuiLifecycleSyncTests(unittest.TestCase):
-    def test_initialize_helper_syncs_ui_after_successful_connect(self):
+    def test_initialize_helper_requests_live_state_reconcile_after_successful_connect(self):
         gui = type("GuiStub", (), {})()
         gui._prompt_install_or_upgrade = MagicMock(return_value=True)
         gui.helper = MagicMock()
@@ -117,14 +117,16 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.root = type("Root", (), {"after": MagicMock()})()
         gui.check_ec_status = MagicMock()
         gui.sync_ui_from_display_state = MagicMock()
+        gui._reconcile_from_live_state = MagicMock()
 
+        # Helper init is also a trigger: it must request one reconcile after connect.
         with patch.object(Tinta4Plus.EInkControlGUI, "_start_event_watcher"), \
              patch.object(Tinta4Plus.EInkControlGUI, "_schedule_event_watcher_poll"):
             Tinta4Plus.EInkControlGUI.initialize_helper(gui)
 
-        gui.sync_ui_from_display_state.assert_called_once()
+        gui._reconcile_from_live_state.assert_called_once()
 
-    def test_attempt_helper_restart_syncs_ui_after_successful_reconnect(self):
+    def test_attempt_helper_restart_requests_live_state_reconcile_after_successful_reconnect(self):
         gui = type("GuiStub", (), {})()
         gui.log_message = MagicMock()
         gui.helper = MagicMock()
@@ -137,15 +139,16 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.root = type("Root", (), {"after": MagicMock()})()
         gui.check_ec_status = MagicMock()
         gui.sync_ui_from_display_state = MagicMock()
+        gui._reconcile_from_live_state = MagicMock()
 
         with patch.object(Tinta4Plus.time, "sleep", return_value=None), \
              patch.object(Tinta4Plus.EInkControlGUI, "_start_event_watcher"), \
              patch.object(Tinta4Plus.EInkControlGUI, "_schedule_event_watcher_poll"):
             Tinta4Plus.EInkControlGUI.attempt_helper_restart(gui)
 
-        gui.sync_ui_from_display_state.assert_called_once()
+        gui._reconcile_from_live_state.assert_called_once()
 
-    def test_toggle_to_eink_uses_sync_ui_on_success(self):
+    def test_toggle_to_eink_requests_live_state_reconcile_on_success(self):
         gui = type("GuiStub", (), {})()
         gui.eink_enabled_var = FakeVar(False)
         gui.display_mgr = object()
@@ -155,6 +158,7 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.autoswitch_theme_var = FakeVar(True)
         gui.brightness_var = FakeVar(4)
         gui.sync_ui_from_display_state = MagicMock()
+        gui._reconcile_from_live_state = MagicMock()
         gui.log_message = MagicMock()
         gui.root = object()
         gui.on_refresh_full = MagicMock()
@@ -170,9 +174,9 @@ class GuiLifecycleSyncTests(unittest.TestCase):
              patch.object(Tinta4Plus, "FloatingRefreshButton", MagicMock()):
             Tinta4Plus.EInkControlGUI.on_eink_toggled(gui)
 
-        gui.sync_ui_from_display_state.assert_called_once()
+        gui._reconcile_from_live_state.assert_called_once()
 
-    def test_toggle_to_oled_uses_sync_ui_on_success(self):
+    def test_toggle_to_oled_requests_live_state_reconcile_on_success(self):
         gui = type("GuiStub", (), {})()
         gui.eink_enabled_var = FakeVar(True)
         gui.display_mgr = object()
@@ -181,6 +185,7 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.display_scale = 1.75
         gui.autoswitch_theme_var = FakeVar(True)
         gui.sync_ui_from_display_state = MagicMock()
+        gui._reconcile_from_live_state = MagicMock()
         gui.log_message = MagicMock()
         gui._stop_refresh_timer = MagicMock()
         gui.floating_refresh_button = None
@@ -193,7 +198,7 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         with patch.object(Tinta4Plus, "switch_to_oled", return_value=True):
             Tinta4Plus.EInkControlGUI.on_eink_toggled(gui)
 
-        gui.sync_ui_from_display_state.assert_called_once()
+        gui._reconcile_from_live_state.assert_called_once()
 
     def test_on_closing_does_not_toggle_display_mode(self):
         gui = type("GuiStub", (), {})()
@@ -719,20 +724,19 @@ class ActivationTouchReconcileTests(unittest.TestCase):
         gui.root = MagicMock()
         gui.floating_refresh_button = None
         gui.on_refresh_full = MagicMock()
+        gui._reconcile_from_live_state = MagicMock()
         return gui
 
-    def test_main_window_activation_runs_reconcile_with_derived_target(self):
+    def test_main_window_activation_requests_live_state_reconcile(self):
         gui = self.make_gui()
 
+        # Activation is a trigger only: policy execution must happen inside reconciler.
         with patch.object(Tinta4Plus.time, "monotonic", return_value=100.0), \
              patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch:
             Tinta4Plus.EInkControlGUI._on_window_activated(gui)
 
-        reconcile_touch.assert_called_once_with(
-            gui.logger,
-            gui.display_mgr,
-            reason="window_activation",
-        )
+        gui._reconcile_from_live_state.assert_called_once_with()
+        reconcile_touch.assert_not_called()
 
     def test_main_window_activation_debounce_skips_rapid_duplicates(self):
         gui = self.make_gui()
@@ -743,20 +747,18 @@ class ActivationTouchReconcileTests(unittest.TestCase):
             Tinta4Plus.EInkControlGUI._on_window_activated(gui)
             Tinta4Plus.EInkControlGUI._on_window_activated(gui)
 
-        self.assertEqual(reconcile_touch.call_count, 2)
+        self.assertEqual(gui._reconcile_from_live_state.call_count, 2)
+        reconcile_touch.assert_not_called()
 
-    def test_main_window_activation_handles_skipped_modes_cleanly(self):
+    def test_main_window_activation_non_eink_stays_noop_through_reconcile(self):
         gui = self.make_gui()
 
         with patch.object(Tinta4Plus.time, "monotonic", return_value=100.0), \
              patch.object(Tinta4Plus, "reconcile_touch", return_value=False) as reconcile_touch:
             Tinta4Plus.EInkControlGUI._on_window_activated(gui)
 
-        reconcile_touch.assert_called_once_with(
-            gui.logger,
-            gui.display_mgr,
-            reason="window_activation",
-        )
+        gui._reconcile_from_live_state.assert_called_once_with()
+        reconcile_touch.assert_not_called()
 
     def test_refresh_button_window_binds_same_activation_handler(self):
         gui = self.make_gui()

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -210,6 +210,94 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.root.destroy.assert_called_once()
 
 
+class OrientationUiTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.display_mgr = MagicMock()
+        gui.orientation_toggle_btn = FakeWidget()
+        gui.orientation_rotation = None
+        gui.log_message = MagicMock()
+        gui.update_status = MagicMock()
+        gui.logger = MagicMock()
+        return gui
+
+    def test_sync_orientation_on_startup_updates_button_from_live_display_state(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-1"
+        gui.display_mgr.get_display_rotation.return_value = "left"
+
+        Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+
+        self.assertEqual(gui.orientation_rotation, "left")
+        self.assertEqual(gui.orientation_toggle_btn.cget("text"), "Orientation: Portrait")
+        self.assertEqual(gui.orientation_toggle_btn.cget("state"), "normal")
+
+    def test_sync_orientation_disables_button_when_no_active_display(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = None
+
+        Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+
+        self.assertEqual(gui.orientation_toggle_btn.cget("state"), "disabled")
+
+    def test_toggle_orientation_switches_between_landscape_and_portrait(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-2"
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "normal", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True), \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+            Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
+
+        self.assertEqual(gui.orientation_toggle_btn.cget("text"), "Orientation: Portrait")
+
+    def test_toggle_orientation_reapplies_input_mode_on_success(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-1"
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "normal", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+            Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
+
+        apply_mode.assert_called_once_with(gui.logger, "oled")
+
+    def test_toggle_orientation_updates_ui_after_confirming_live_rotation(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-1"
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "normal", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True), \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+            Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
+
+        gui.display_mgr.get_display_rotation.assert_called_with("eDP-1")
+        self.assertEqual(gui.orientation_rotation, "left")
+
+    def test_failed_toggle_keeps_last_confirmed_orientation_label(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-1"
+        gui.display_mgr.get_display_rotation.return_value = "normal"
+        gui.display_mgr.set_display_rotation.return_value = False
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True), \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+            Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
+
+        self.assertEqual(gui.orientation_toggle_btn.cget("text"), "Orientation: Landscape")
+
+
 class FrontlightRecoveryTests(unittest.TestCase):
     def make_gui(self, ec_status):
         gui = type("GuiStub", (), {})()

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -209,6 +209,22 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.helper.disconnect.assert_called_once()
         gui.root.destroy.assert_called_once()
 
+    def test_on_closing_stops_event_watcher_and_lid_inhibitor(self):
+        gui = type("GuiStub", (), {})()
+        gui.logger = MagicMock()
+        gui.log_message = MagicMock()
+        gui._stop_refresh_timer = MagicMock()
+        gui.helper = MagicMock()
+        gui.helper.is_connected.return_value = False
+        gui.root = MagicMock()
+
+        with patch.object(Tinta4Plus.EInkControlGUI, "_stop_event_watcher") as stop_watcher, \
+             patch.object(Tinta4Plus.EInkControlGUI, "_stop_lid_inhibitor") as stop_inhibitor:
+            Tinta4Plus.EInkControlGUI.on_closing(gui)
+
+        stop_watcher.assert_called_once_with(gui)
+        stop_inhibitor.assert_called_once_with(gui)
+
 
 class OrientationUiTests(unittest.TestCase):
     def make_gui(self):
@@ -595,6 +611,17 @@ class EventWatcherNotificationTests(unittest.TestCase):
 
         self.assertEqual(gui._reconcile_from_live_state.call_count, 2)
 
+    def test_randr_notification_triggers_live_state_resync(self):
+        gui = self.make_gui()
+        conn = MagicMock()
+        conn.poll.side_effect = [True, False]
+        conn.recv.return_value = ("randr", None)
+        gui._event_watcher_conn = conn
+
+        Tinta4Plus.EInkControlGUI._drain_event_watcher_notifications(gui)
+
+        gui._reconcile_from_live_state.assert_called_once()
+
     def test_notification_drain_does_not_do_direct_side_effects(self):
         gui = self.make_gui()
         gui.sync_ui_from_display_state = MagicMock()
@@ -618,6 +645,18 @@ class EventWatcherNotificationTests(unittest.TestCase):
 
         gui.log_message.assert_called_once()
         gui._reconcile_from_live_state.assert_not_called()
+
+    def test_closed_notification_pipe_does_not_crash_and_disables_watcher_conn(self):
+        gui = self.make_gui()
+        conn = MagicMock()
+        conn.poll.side_effect = [True]
+        conn.recv.side_effect = EOFError()
+        gui._event_watcher_conn = conn
+
+        Tinta4Plus.EInkControlGUI._drain_event_watcher_notifications(gui)
+
+        self.assertIsNone(gui._event_watcher_conn)
+        gui.log_message.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -26,6 +26,19 @@ class FakeWidget:
         return self.props.get(key)
 
 
+class FakeWarningWidget(FakeWidget):
+    def __init__(self):
+        super().__init__()
+        self.grid_called = False
+        self.grid_remove_called = False
+
+    def grid(self, **_kwargs):
+        self.grid_called = True
+
+    def grid_remove(self):
+        self.grid_remove_called = True
+
+
 class UiStateSyncTests(unittest.TestCase):
     def make_gui(self):
         gui = type("GuiStub", (), {})()
@@ -177,6 +190,40 @@ class GuiLifecycleSyncTests(unittest.TestCase):
             Tinta4Plus.EInkControlGUI.on_eink_toggled(gui)
 
         gui.sync_ui_from_display_state.assert_called_once()
+
+
+class FrontlightRecoveryTests(unittest.TestCase):
+    def make_gui(self, ec_status):
+        gui = type("GuiStub", (), {})()
+        gui.helper = MagicMock()
+        gui.helper.send_command.return_value = {"success": True, "ec_status": ec_status}
+        gui.secureboot_label = FakeWidget()
+        gui.secureboot_frame = FakeWidget()
+        gui.secure_boot_warning = FakeWarningWidget()
+        gui.brightness_scale = FakeWidget()
+        gui.log_message = MagicMock()
+        gui.sync_frontlight_state = MagicMock()
+        gui.logger = MagicMock()
+        return gui
+
+    def test_check_ec_status_enables_slider_hides_warning_and_syncs_when_available(self):
+        gui = self.make_gui({"secure_boot_enabled": False, "available": True})
+
+        Tinta4Plus.EInkControlGUI.check_ec_status(gui)
+
+        self.assertEqual(gui.brightness_scale.cget("state"), "normal")
+        self.assertTrue(gui.secure_boot_warning.grid_remove_called)
+        gui.sync_frontlight_state.assert_called_once()
+
+    def test_check_ec_status_disables_slider_and_shows_warning_when_unavailable(self):
+        gui = self.make_gui({"secure_boot_enabled": False, "available": False, "error_message": "denied"})
+
+        with patch.object(Tinta4Plus.messagebox, "showwarning", MagicMock()):
+            Tinta4Plus.EInkControlGUI.check_ec_status(gui)
+
+        self.assertEqual(gui.brightness_scale.cget("state"), "disabled")
+        self.assertTrue(gui.secure_boot_warning.grid_called)
+        gui.sync_frontlight_state.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import Tinta4Plus
+
+
+class FakeVar:
+    def __init__(self, value=None):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+class FakeWidget:
+    def __init__(self):
+        self.props = {}
+
+    def config(self, **kwargs):
+        self.props.update(kwargs)
+
+    def cget(self, key):
+        return self.props.get(key)
+
+
+class UiStateSyncTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.display_mgr = object()
+        gui.eink_enabled_var = FakeVar(False)
+        gui.eink_toggle_btn = FakeWidget()
+        gui.btn_refresh = FakeWidget()
+        gui.btn_set_dynamic = FakeWidget()
+        gui.btn_set_reading = FakeWidget()
+        gui._start_refresh_timer = MagicMock()
+        gui._stop_refresh_timer = MagicMock()
+        gui._ensure_floating_refresh_button = MagicMock()
+        gui._destroy_floating_refresh_button = MagicMock()
+        gui.log_message = MagicMock()
+        gui.update_status = MagicMock()
+        return gui
+
+    def test_eink_state_enables_controls_and_refresh_lifecycle(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"oled_active": False, "eink_active": True, "mode": "eink"}):
+            Tinta4Plus.EInkControlGUI.sync_ui_from_display_state(gui)
+
+        self.assertTrue(gui.eink_enabled_var.get())
+        self.assertEqual(gui.eink_toggle_btn.cget("text"), "eInk Enabled")
+        self.assertEqual(gui.btn_refresh.cget("state"), "normal")
+        self.assertEqual(gui.btn_set_dynamic.cget("state"), "normal")
+        self.assertEqual(gui.btn_set_reading.cget("state"), "normal")
+        gui._start_refresh_timer.assert_called_once()
+        gui._ensure_floating_refresh_button.assert_called_once()
+        gui._stop_refresh_timer.assert_not_called()
+        gui._destroy_floating_refresh_button.assert_not_called()
+
+    def test_oled_state_disables_controls_and_refresh_lifecycle(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"oled_active": True, "eink_active": False, "mode": "oled"}):
+            Tinta4Plus.EInkControlGUI.sync_ui_from_display_state(gui)
+
+        self.assertFalse(gui.eink_enabled_var.get())
+        self.assertEqual(gui.eink_toggle_btn.cget("text"), "eInk Disabled")
+        self.assertEqual(gui.btn_refresh.cget("state"), "disabled")
+        self.assertEqual(gui.btn_set_dynamic.cget("state"), "disabled")
+        self.assertEqual(gui.btn_set_reading.cget("state"), "disabled")
+        gui._stop_refresh_timer.assert_called_once()
+        gui._destroy_floating_refresh_button.assert_called_once()
+        gui._start_refresh_timer.assert_not_called()
+        gui._ensure_floating_refresh_button.assert_not_called()
+
+    def test_unknown_or_mixed_state_stays_conservatively_disabled(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"oled_active": True, "eink_active": True, "mode": "mixed"}):
+            Tinta4Plus.EInkControlGUI.sync_ui_from_display_state(gui)
+
+        self.assertFalse(gui.eink_enabled_var.get())
+        self.assertEqual(gui.eink_toggle_btn.cget("text"), "eInk Disabled")
+        self.assertEqual(gui.btn_refresh.cget("state"), "disabled")
+        self.assertEqual(gui.btn_set_dynamic.cget("state"), "disabled")
+        self.assertEqual(gui.btn_set_reading.cget("state"), "disabled")
+        gui._stop_refresh_timer.assert_called_once()
+        gui._destroy_floating_refresh_button.assert_called_once()
+        gui.log_message.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -118,7 +118,9 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.check_ec_status = MagicMock()
         gui.sync_ui_from_display_state = MagicMock()
 
-        Tinta4Plus.EInkControlGUI.initialize_helper(gui)
+        with patch.object(Tinta4Plus.EInkControlGUI, "_start_event_watcher"), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_schedule_event_watcher_poll"):
+            Tinta4Plus.EInkControlGUI.initialize_helper(gui)
 
         gui.sync_ui_from_display_state.assert_called_once()
 
@@ -136,7 +138,9 @@ class GuiLifecycleSyncTests(unittest.TestCase):
         gui.check_ec_status = MagicMock()
         gui.sync_ui_from_display_state = MagicMock()
 
-        with patch.object(Tinta4Plus.time, "sleep", return_value=None):
+        with patch.object(Tinta4Plus.time, "sleep", return_value=None), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_start_event_watcher"), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_schedule_event_watcher_poll"):
             Tinta4Plus.EInkControlGUI.attempt_helper_restart(gui)
 
         gui.sync_ui_from_display_state.assert_called_once()

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -282,11 +282,18 @@ class OrientationUiTests(unittest.TestCase):
 
         with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
              patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch, \
              patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
             Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
             Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
 
         apply_mode.assert_called_once_with(gui.logger, "oled")
+        reconcile_touch.assert_called_once_with(
+            gui.logger,
+            gui.display_mgr,
+            target="oled",
+            reason="orientation_toggled",
+        )
 
     def test_toggle_orientation_runs_touch_recovery_for_current_target(self):
         gui = self.make_gui()
@@ -296,12 +303,42 @@ class OrientationUiTests(unittest.TestCase):
 
         with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
              patch.object(Tinta4Plus, "_apply_input_mode", return_value=True), \
-             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch, \
              patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
             Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
             Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
 
-        ensure_touch.assert_called_once_with(gui.logger, "oled")
+        reconcile_touch.assert_called_once_with(
+            gui.logger,
+            gui.display_mgr,
+            target="oled",
+            reason="orientation_toggled",
+        )
+
+    def test_toggle_orientation_applies_input_mode_before_touch_reconcile(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_active_display.return_value = "eDP-1"
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "normal", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+
+        call_order = []
+
+        def record_apply(*_args, **_kwargs):
+            call_order.append("apply")
+            return True
+
+        def record_reconcile(*_args, **_kwargs):
+            call_order.append("reconcile")
+            return True
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus, "_apply_input_mode", side_effect=record_apply), \
+             patch.object(Tinta4Plus, "reconcile_touch", side_effect=record_reconcile), \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI.sync_orientation_from_display_state(gui)
+            Tinta4Plus.EInkControlGUI.on_orientation_toggled(gui)
+
+        self.assertEqual(call_order, ["apply", "reconcile"])
 
     def test_toggle_orientation_updates_ui_after_confirming_live_rotation(self):
         gui = self.make_gui()
@@ -484,13 +521,18 @@ class LidDrivenRotationTests(unittest.TestCase):
              patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
              patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc), \
              patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
-             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch, \
              patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
             Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
 
         gui.display_mgr.set_display_rotation.assert_called_once_with("eDP-2", "left")
         apply_mode.assert_called_once_with(gui.logger, "eink")
-        ensure_touch.assert_called_once_with(gui.logger, "eink")
+        reconcile_touch.assert_called_once_with(
+            gui.logger,
+            gui.display_mgr,
+            target="eink",
+            reason="lid_state_reconcile",
+        )
 
     def test_eink_plus_lid_open_rotates_to_landscape_and_recovers_touch(self):
         gui = self.make_gui()
@@ -503,13 +545,18 @@ class LidDrivenRotationTests(unittest.TestCase):
              patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=False), \
              patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc), \
              patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
-             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch, \
              patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
             Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
 
         gui.display_mgr.set_display_rotation.assert_called_once_with("eDP-2", "normal")
         apply_mode.assert_called_once_with(gui.logger, "eink")
-        ensure_touch.assert_called_once_with(gui.logger, "eink")
+        reconcile_touch.assert_called_once_with(
+            gui.logger,
+            gui.display_mgr,
+            target="eink",
+            reason="lid_state_reconcile",
+        )
 
     def test_not_eink_mode_does_not_apply_lid_driven_rotation(self):
         gui = self.make_gui()
@@ -517,12 +564,12 @@ class LidDrivenRotationTests(unittest.TestCase):
         with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
              patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
              patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
-             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch:
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch:
             Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
 
         gui.display_mgr.set_display_rotation.assert_not_called()
         apply_mode.assert_not_called()
-        ensure_touch.assert_not_called()
+        reconcile_touch.assert_not_called()
 
     def test_duplicate_invalidation_with_no_effective_change_is_ignored(self):
         gui = self.make_gui()
@@ -535,7 +582,7 @@ class LidDrivenRotationTests(unittest.TestCase):
              patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
              patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc), \
              patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
-             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True), \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True), \
              patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
             Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
             Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
@@ -661,6 +708,68 @@ class EventWatcherNotificationTests(unittest.TestCase):
 
         self.assertIsNone(gui._event_watcher_conn)
         gui.log_message.assert_called_once()
+
+
+class ActivationTouchReconcileTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.logger = MagicMock()
+        gui.display_mgr = MagicMock()
+        gui.log_message = MagicMock()
+        gui.root = MagicMock()
+        gui.floating_refresh_button = None
+        gui.on_refresh_full = MagicMock()
+        return gui
+
+    def test_main_window_activation_runs_reconcile_with_derived_target(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus.time, "monotonic", return_value=100.0), \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch:
+            Tinta4Plus.EInkControlGUI._on_window_activated(gui)
+
+        reconcile_touch.assert_called_once_with(
+            gui.logger,
+            gui.display_mgr,
+            reason="window_activation",
+        )
+
+    def test_main_window_activation_debounce_skips_rapid_duplicates(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus.time, "monotonic", side_effect=[10.0, 10.1, 10.8]), \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=True) as reconcile_touch:
+            Tinta4Plus.EInkControlGUI._on_window_activated(gui)
+            Tinta4Plus.EInkControlGUI._on_window_activated(gui)
+            Tinta4Plus.EInkControlGUI._on_window_activated(gui)
+
+        self.assertEqual(reconcile_touch.call_count, 2)
+
+    def test_main_window_activation_handles_skipped_modes_cleanly(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus.time, "monotonic", return_value=100.0), \
+             patch.object(Tinta4Plus, "reconcile_touch", return_value=False) as reconcile_touch:
+            Tinta4Plus.EInkControlGUI._on_window_activated(gui)
+
+        reconcile_touch.assert_called_once_with(
+            gui.logger,
+            gui.display_mgr,
+            reason="window_activation",
+        )
+
+    def test_refresh_button_window_binds_same_activation_handler(self):
+        gui = self.make_gui()
+        fake_window = MagicMock()
+        fake_button = type("FloatButtonStub", (), {"window": fake_window})()
+
+        with patch.object(Tinta4Plus, "FloatingRefreshButton", return_value=fake_button):
+            Tinta4Plus.EInkControlGUI._ensure_floating_refresh_button(gui)
+
+        self.assertIs(gui.floating_refresh_button, fake_button)
+        fake_window.bind.assert_called_once()
+        bind_args = fake_window.bind.call_args[0]
+        self.assertEqual(bind_args[0], "<FocusIn>")
 
 
 if __name__ == "__main__":

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -443,6 +443,87 @@ class InhibitorLifecycleTests(unittest.TestCase):
         popen.assert_called_once()
 
 
+class LidDrivenRotationTests(unittest.TestCase):
+    def make_gui(self):
+        gui = type("GuiStub", (), {})()
+        gui.display_mgr = MagicMock()
+        gui.display_mgr.get_active_display.return_value = "eDP-2"
+        gui.sync_ui_from_display_state = MagicMock()
+        gui.logger = MagicMock()
+        gui.log_message = MagicMock()
+        return gui
+
+    def test_eink_plus_lid_closed_rotates_to_portrait_and_recovers_touch(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
+             patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
+             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        gui.display_mgr.set_display_rotation.assert_called_once_with("eDP-2", "left")
+        apply_mode.assert_called_once_with(gui.logger, "eink")
+        ensure_touch.assert_called_once_with(gui.logger, "eink")
+
+    def test_eink_plus_lid_open_rotates_to_landscape_and_recovers_touch(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_display_rotation.side_effect = ["left", "normal"]
+        gui.display_mgr.set_display_rotation.return_value = True
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=False), \
+             patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
+             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch, \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        gui.display_mgr.set_display_rotation.assert_called_once_with("eDP-2", "normal")
+        apply_mode.assert_called_once_with(gui.logger, "eink")
+        ensure_touch.assert_called_once_with(gui.logger, "eink")
+
+    def test_not_eink_mode_does_not_apply_lid_driven_rotation(self):
+        gui = self.make_gui()
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "oled"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
+             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True) as ensure_touch:
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        gui.display_mgr.set_display_rotation.assert_not_called()
+        apply_mode.assert_not_called()
+        ensure_touch.assert_not_called()
+
+    def test_duplicate_invalidation_with_no_effective_change_is_ignored(self):
+        gui = self.make_gui()
+        gui.display_mgr.get_display_rotation.side_effect = ["normal", "left", "left"]
+        gui.display_mgr.set_display_rotation.return_value = True
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with patch.object(Tinta4Plus, "get_display_state", return_value={"mode": "eink"}), \
+             patch.object(Tinta4Plus.EInkControlGUI, "_read_live_lid_state", return_value=True), \
+             patch.object(Tinta4Plus.subprocess, "Popen", return_value=fake_proc), \
+             patch.object(Tinta4Plus, "_apply_input_mode", return_value=True) as apply_mode, \
+             patch.object(Tinta4Plus, "ensure_touch_available", return_value=True), \
+             patch.object(Tinta4Plus, "save_orientation_preference", return_value=True):
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+            Tinta4Plus.EInkControlGUI._reconcile_from_live_state(gui)
+
+        gui.display_mgr.set_display_rotation.assert_called_once_with("eDP-2", "left")
+        apply_mode.assert_called_once_with(gui.logger, "eink")
+
+
 class EventWatcherLifecycleTests(unittest.TestCase):
     def make_gui(self):
         gui = type("GuiStub", (), {})()

--- a/tests/test_tinta4plus_ui_state.py
+++ b/tests/test_tinta4plus_ui_state.py
@@ -408,6 +408,24 @@ class FrontlightRecoveryTests(unittest.TestCase):
         self.assertTrue(gui.secure_boot_warning.grid_called)
         gui.sync_frontlight_state.assert_not_called()
 
+    def test_check_ec_status_handles_keyboard_interrupt_by_closing(self):
+        gui = self.make_gui({"secure_boot_enabled": False, "available": True})
+        gui.helper.send_command.side_effect = KeyboardInterrupt()
+        gui.on_closing = MagicMock()
+
+        Tinta4Plus.EInkControlGUI.check_ec_status(gui)
+
+        gui.on_closing.assert_called_once()
+
+    def test_sync_frontlight_state_handles_keyboard_interrupt_by_closing(self):
+        gui = self.make_gui({"secure_boot_enabled": False, "available": True})
+        gui.helper.send_command.side_effect = KeyboardInterrupt()
+        gui.on_closing = MagicMock()
+
+        Tinta4Plus.EInkControlGUI.sync_frontlight_state(gui)
+
+        gui.on_closing.assert_called_once()
+
 
 class LiveStateReconcilerTests(unittest.TestCase):
     def make_gui(self):

--- a/tests/test_unix_socket_protocol.py
+++ b/tests/test_unix_socket_protocol.py
@@ -25,6 +25,7 @@ class FakeSocket:
         return chunk
 
 
+@unittest.skip("Legacy length-prefixed protocol tests kept as migration baseline")
 class UnixSocketProtocolTests(unittest.TestCase):
     def test_helper_client_send_command_uses_length_prefixed_json_protocol(self):
         logger = Mock()

--- a/tests/test_unix_socket_protocol.py
+++ b/tests/test_unix_socket_protocol.py
@@ -1,0 +1,110 @@
+import json
+import socket
+import struct
+import threading
+import unittest
+from unittest.mock import Mock
+
+from HelperClient import HelperClient
+from HelperDaemon import HelperDaemon
+
+
+class FakeSocket:
+    def __init__(self, response_bytes):
+        self.response_bytes = response_bytes
+        self.sent = b""
+
+    def sendall(self, data):
+        self.sent += data
+
+    def recv(self, n):
+        if not self.response_bytes:
+            return b""
+        chunk = self.response_bytes[:n]
+        self.response_bytes = self.response_bytes[n:]
+        return chunk
+
+
+class UnixSocketProtocolTests(unittest.TestCase):
+    def test_helper_client_send_command_uses_length_prefixed_json_protocol(self):
+        logger = Mock()
+        client = HelperClient(logger)
+
+        response = {"success": True, "message": "ok"}
+        response_json = json.dumps(response).encode("utf-8")
+        fake_sock = FakeSocket(struct.pack("!I", len(response_json)) + response_json)
+
+        client.socket = fake_sock
+        client.connected = True
+
+        result = client.send_command("refresh-eink", mode="full")
+
+        self.assertEqual(result, response)
+
+        sent_length = struct.unpack("!I", fake_sock.sent[:4])[0]
+        sent_payload = fake_sock.sent[4:]
+        self.assertEqual(sent_length, len(sent_payload))
+
+        sent_json = json.loads(sent_payload.decode("utf-8"))
+        self.assertEqual(sent_json["command"], "refresh-eink")
+        self.assertEqual(sent_json["params"], {"mode": "full"})
+
+    def test_helper_daemon_send_response_uses_length_prefix(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+
+        server_sock, client_sock = socket.socketpair()
+        try:
+            daemon._send_response(server_sock, {"success": True, "value": 123})
+
+            length_data = client_sock.recv(4)
+            self.assertEqual(len(length_data), 4)
+            response_len = struct.unpack("!I", length_data)[0]
+
+            payload = b""
+            while len(payload) < response_len:
+                payload += client_sock.recv(response_len - len(payload))
+
+            parsed = json.loads(payload.decode("utf-8"))
+            self.assertEqual(parsed, {"success": True, "value": 123})
+        finally:
+            server_sock.close()
+            client_sock.close()
+
+    def test_helper_daemon_handle_client_processes_length_prefixed_command(self):
+        logger = Mock()
+        daemon = HelperDaemon(logger)
+        daemon.running = True
+        daemon.handle_command = lambda cmd: {"success": True, "echo": cmd["command"]}
+
+        server_sock, client_sock = socket.socketpair()
+
+        def run_handler():
+            daemon.handle_client(server_sock)
+
+        t = threading.Thread(target=run_handler, daemon=True)
+        t.start()
+
+        try:
+            command = {"command": "set-reading", "params": {}}
+            payload = json.dumps(command).encode("utf-8")
+            client_sock.sendall(struct.pack("!I", len(payload)) + payload)
+
+            response_len_data = client_sock.recv(4)
+            self.assertEqual(len(response_len_data), 4)
+            response_len = struct.unpack("!I", response_len_data)[0]
+
+            response_payload = b""
+            while len(response_payload) < response_len:
+                response_payload += client_sock.recv(response_len - len(response_payload))
+
+            response = json.loads(response_payload.decode("utf-8"))
+            self.assertEqual(response, {"success": True, "echo": "set-reading"})
+        finally:
+            daemon.running = False
+            client_sock.close()
+            t.join(timeout=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toggle-eink.py
+++ b/toggle-eink.py
@@ -14,14 +14,21 @@ SOCKET_PATH = "/run/tinta4plus.sock"
 DEFAULT_SCALE = 1.75
 CONFIG_DIR = os.path.expanduser("~/.config/Tinta4Plus")
 SETTINGS_FILE = os.path.join(CONFIG_DIR, "settings")
+LOG_FILE = "/tmp/TintaHelper.log"
 
 
 def setup_logger():
     logger = logging.getLogger("toggle-eink")
     logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    logger.handlers = [handler]
+    logger.propagate = False
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(logging.Formatter("%(message)s"))
+
+    file_handler = logging.FileHandler(LOG_FILE, mode='a')
+    file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+
+    logger.handlers = [stream_handler, file_handler]
     return logger
 
 

--- a/toggle-eink.py
+++ b/toggle-eink.py
@@ -25,10 +25,15 @@ def setup_logger():
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(logging.Formatter("%(message)s"))
 
-    file_handler = logging.FileHandler(LOG_FILE, mode='a')
-    file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+    handlers = [stream_handler]
+    try:
+        file_handler = logging.FileHandler(LOG_FILE, mode='a')
+        file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+        handlers.append(file_handler)
+    except Exception as e:
+        print(f"Warning: could not open {LOG_FILE} for append logging: {e}", file=sys.stderr)
 
-    logger.handlers = [stream_handler, file_handler]
+    logger.handlers = handlers
     return logger
 
 

--- a/toggle-eink.py
+++ b/toggle-eink.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Minimal CLI toggle for ThinkBook Plus Gen4 OLED <-> E-Ink."""
+
+import json
+import logging
+import os
+import sys
+
+from DisplayManager import DisplayManager
+from HelperClient import HelperClient
+from mode_switch import DISPLAY_EINK, switch_to_eink, switch_to_oled
+
+SOCKET_PATH = "/run/tinta4plus.sock"
+DEFAULT_SCALE = 1.75
+CONFIG_DIR = os.path.expanduser("~/.config/Tinta4Plus")
+SETTINGS_FILE = os.path.join(CONFIG_DIR, "settings")
+
+
+def setup_logger():
+    logger = logging.getLogger("toggle-eink")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.handlers = [handler]
+    return logger
+
+
+def load_settings(logger):
+    defaults = {
+        "display_scale": DEFAULT_SCALE,
+        "autoswitch_theme": True,
+    }
+
+    if not os.path.exists(SETTINGS_FILE):
+        return defaults
+
+    try:
+        with open(SETTINGS_FILE, "r") as f:
+            settings = json.load(f)
+    except Exception as e:
+        logger.warning(f"Failed to load settings, using defaults: {e}")
+        return defaults
+
+    return {
+        "display_scale": settings.get("display_scale", defaults["display_scale"]),
+        "autoswitch_theme": settings.get("autoswitch_theme", defaults["autoswitch_theme"]),
+    }
+
+
+def main():
+    logger = setup_logger()
+    display_mgr = DisplayManager(logger)
+    helper = HelperClient(logger)
+
+    try:
+        if not helper.connect(SOCKET_PATH, timeout=10.0):
+            logger.error("Could not connect to helper at /run/tinta4plus.sock")
+            logger.error("Try: systemctl status tinta4plus-helper.socket")
+            return 1
+
+        settings = load_settings(logger)
+        scale = settings["display_scale"]
+        autoswitch_theme = settings["autoswitch_theme"]
+
+        eink_active = display_mgr.is_display_active(DISPLAY_EINK)
+
+        if eink_active:
+            ok = switch_to_oled(
+                display_mgr,
+                helper,
+                logger,
+                scale=scale,
+                autoswitch_theme=autoswitch_theme,
+                script_dir=os.path.dirname(os.path.abspath(__file__)),
+            )
+        else:
+            ok = switch_to_eink(
+                display_mgr,
+                helper,
+                logger,
+                scale=scale,
+                autoswitch_theme=autoswitch_theme,
+                enable_frontlight=True,
+                brightness_level=4,
+            )
+
+        return 0 if ok else 1
+
+    except Exception as e:
+        logger.error(f"Toggle failed: {e}")
+        return 1
+    finally:
+        try:
+            if helper.is_connected():
+                helper.disconnect()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/toggle-eink.py
+++ b/toggle-eink.py
@@ -8,7 +8,7 @@ import sys
 
 from DisplayManager import DisplayManager
 from HelperClient import HelperClient
-from mode_switch import DISPLAY_EINK, switch_to_eink, switch_to_oled
+from mode_switch import get_display_state, switch_to_eink, switch_to_oled
 
 SOCKET_PATH = "/run/tinta4plus.sock"
 DEFAULT_SCALE = 1.75
@@ -62,9 +62,9 @@ def main():
         scale = settings["display_scale"]
         autoswitch_theme = settings["autoswitch_theme"]
 
-        eink_active = display_mgr.is_display_active(DISPLAY_EINK)
+        state = get_display_state(display_mgr)
 
-        if eink_active:
+        if state["mode"] == "eink":
             ok = switch_to_oled(
                 display_mgr,
                 helper,


### PR DESCRIPTION
## Summary
This branch is now organized as an LKML-style patch series and rebased onto `main`.

### Patch series
1. helper: harden client-daemon protocol error handling
2. display: improve xrandr output discovery and caching
3. helper: use systemd socket activation and /run runtime paths
4. modeswitch: share OLED/EInk transitions and harden state handling
5. cli: add toggle-eink utility using shared mode-switch path
6. power: remove GUI keepalive and daemon watchdog polling
7. tests: add baseline coverage for unix-socket protocol
8. docs: clarify v1 endpoints and access logging plan
9. gitignore: ignore local worktree directory
10. client: route helper commands through v1 HTTP endpoints
11. daemon: add v1 HTTP unix-socket routes and access logs
12. frontlight: treat brightness level 0 as disabled

## Notes
- Commit history cleaned and reworded for reviewability/bisectability.
- `frontlight` patch includes DRY cleanup for response assembly in `HelperDaemon`.
